### PR TITLE
Add blog post on GitHub PR automerging

### DIFF
--- a/posts/2025-10-20-github-pr-automerging.md
+++ b/posts/2025-10-20-github-pr-automerging.md
@@ -6,7 +6,7 @@ layout: post
 title: "Automate GitHub PR Merging for Efficient Workflows"
 ---
 
-GitHub's automerge feature streamlines development by automatically merging pull requests once all checks pass. This can significantly speed up your team's workflow, especially in projects with continuous integration and delivery.
+GitHub's automerge feature streamlines development by automatically merging pull requests once all checks pass, *provided that all branch protection rules are satisfied*. This can significantly speed up your team's workflow, especially in projects with continuous integration and delivery.
 
 ### How to Enable Automerge
 
@@ -16,3 +16,14 @@ To enable automerge for a pull request:
 2.  **Click the "Enable auto-merge" option:** This button appears on the pull request page once all conditions are met.
 
 Once enabled, GitHub will automatically merge the PR when it's ready, freeing you from manual monitoring. This is particularly useful for small, self-contained changes or when you're confident in your automated testing.
+
+### The Role of Branch Protection Rules
+
+Branch protection rules are crucial for maintaining code quality and ensuring that only well-vetted changes are merged into important branches like `main`. For automerge to function effectively and safely, you must configure branch protection rules to enforce the necessary checks before a PR can be merged. These rules can include:
+
+*   **Requiring a minimum number of approving reviews:** Ensures that code is reviewed by peers.
+*   **Requiring status checks to pass before merging:** Guarantees that CI/CD pipelines and other automated tests complete successfully.
+*   **Requiring branches to be up to date before merging:** Prevents merging stale branches that might introduce conflicts.
+*   **Including a `CODEOWNERS` file:** Automatically requests reviews from designated team members for specific parts of the codebase.
+
+By setting up robust branch protection rules, you can leverage automerge to accelerate your development process without compromising on code quality or stability.

--- a/posts/2025-10-20-github-pr-automerging.md
+++ b/posts/2025-10-20-github-pr-automerging.md
@@ -1,0 +1,18 @@
+---
+categories:
+  - software
+date: 2025-10-20 00:00
+layout: post
+title: "Automate GitHub PR Merging for Efficient Workflows"
+---
+
+GitHub's automerge feature streamlines development by automatically merging pull requests once all checks pass. This can significantly speed up your team's workflow, especially in projects with continuous integration and delivery.
+
+### How to Enable Automerge
+
+To enable automerge for a pull request:
+
+1.  **Ensure all required checks are passing:** This includes CI/CD pipelines, code reviews, and any other branch protection rules.
+2.  **Click the "Enable auto-merge" option:** This button appears on the pull request page once all conditions are met.
+
+Once enabled, GitHub will automatically merge the PR when it's ready, freeing you from manual monitoring. This is particularly useful for small, self-contained changes or when you're confident in your automated testing.


### PR DESCRIPTION
This PR adds a new blog post explaining how to use GitHub PR automerging for efficient workflows.