### PR TITLE
Add post on custom JupyterHub Docker image template

### DIFF
--- a/posts/2025-12-01-custom-jupyterhub-docker-image.md
+++ b/posts/2025-12-01-custom-jupyterhub-docker-image.md
@@ -7,7 +7,7 @@ layout: post
 title: Custom JupyterHub Docker image template
 ---
 
-I published a template that builds a ready-to-use JupyterHub single-user image with common scientific Python tooling and JupyterHub-friendly defaults: <https://github.com/zonca/custom-jupyterhub-docker-image>. See the README in that repo for the full list of packages, build steps, and CI workflow details.
+I published a template that builds a ready-to-use JupyterHub single-user image with common scientific Python tooling and JupyterHub-friendly defaults: <https://github.com/zonca/custom-jupyterhub-docker-image>. Clone it, adjust `requirements.txt` (or the Dockerfile/env files) in GitHub, and a GitHub Actions workflow automatically builds and publishes a new image for you—no local Docker needed. See the README in that repo for the full list of packages, build steps, and CI workflow details.
 
 How to use it in JupyterHub:
 

--- a/posts/2025-12-01-custom-jupyterhub-docker-image.md
+++ b/posts/2025-12-01-custom-jupyterhub-docker-image.md
@@ -1,0 +1,19 @@
+---
+categories:
+- jupyterhub
+- docker
+date: '2025-12-01'
+layout: post
+title: Custom JupyterHub Docker image template
+---
+
+I published a template that builds a ready-to-use JupyterHub single-user image with common scientific Python tooling and JupyterHub-friendly defaults: <https://github.com/zonca/custom-jupyterhub-docker-image>. See the README in that repo for the full list of packages, build steps, and CI workflow details.
+
+How to use it in JupyterHub:
+
+- Build or pull the image, then point your spawner at it, e.g. `c.DockerSpawner.image = "ghcr.io/your-org/custom-jupyterhub-docker-image:TAG"` (or the equivalent field for your spawner/Helm chart).
+- Restart JupyterHub so new servers launch with the custom image.
+
+Using the GitHub template model: click “Use this template” on the repository to create your own copy (no fork history), edit the Dockerfile or environment as needed, then push to your org/user namespace.
+
+GitHub can also host the resulting Docker images via GitHub Container Registry; publishing and pulling docs: <https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry>.

--- a/posts/2025-12-01-custom-jupyterhub-docker-image.md
+++ b/posts/2025-12-01-custom-jupyterhub-docker-image.md
@@ -1,7 +1,7 @@
 ---
 categories:
 - jupyterhub
-- docker
+- python
 date: '2025-12-01'
 layout: post
 title: Custom JupyterHub Docker image template

--- a/posts/2025-12-01-custom-jupyterhub-docker-image.md
+++ b/posts/2025-12-01-custom-jupyterhub-docker-image.md
@@ -7,13 +7,13 @@ layout: post
 title: Custom JupyterHub Docker image template
 ---
 
-I published a template that builds a ready-to-use JupyterHub single-user image with common scientific Python tooling and JupyterHub-friendly defaults: <https://github.com/zonca/custom-jupyterhub-docker-image>. Clone it, adjust `requirements.txt` (or the Dockerfile/env files) in GitHub, and a GitHub Actions workflow automatically builds and publishes a new image for you—no local Docker needed. See the README in that repo for the full list of packages, build steps, and CI workflow details.
+Overview: <https://github.com/zonca/custom-jupyterhub-docker-image> is a template that ships a JupyterHub-ready single-user image with common scientific Python tooling and sensible defaults. You edit `requirements.txt` (or Dockerfile/env files) directly in GitHub, and the built-in GitHub Actions workflow auto-builds and publishes a new image—no local Docker required. See the README for the detailed package list and CI steps.
 
 How to use it in JupyterHub:
 
 - Build or pull the image, then point your spawner at it, e.g. `c.DockerSpawner.image = "ghcr.io/your-org/custom-jupyterhub-docker-image:TAG"` (or the equivalent field for your spawner/Helm chart).
 - Restart JupyterHub so new servers launch with the custom image.
 
-Using the GitHub template model: click “Use this template” on the repository to create your own copy (no fork history), edit the Dockerfile or environment as needed, then push to your org/user namespace.
+Adopt it via GitHub templates: click “Use this template” to create your own copy (no fork history), tweak the Dockerfile or environment files, and push to your namespace to trigger the build.
 
-GitHub can also host the resulting Docker images via GitHub Container Registry; publishing and pulling docs: <https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry>.
+Where the image lives: the workflow can publish to GitHub Container Registry. Publish/pull docs: <https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry>.

--- a/posts/2025-12-01-custom-jupyterhub-docker-image.md
+++ b/posts/2025-12-01-custom-jupyterhub-docker-image.md
@@ -7,13 +7,13 @@ layout: post
 title: Custom JupyterHub Docker image template
 ---
 
-Overview: <https://github.com/zonca/custom-jupyterhub-docker-image> is a template that ships a JupyterHub-ready single-user image with common scientific Python tooling and sensible defaults. You edit `requirements.txt` (or Dockerfile/env files) directly in GitHub, and the built-in GitHub Actions workflow auto-builds and publishes a new image—no local Docker required. See the README for the detailed package list and CI steps.
+Overview: <https://github.com/zonca/custom-jupyterhub-docker-image> is a template that ships a JupyterHub-ready single-user image with common scientific Python tooling and sensible defaults. Just edit `requirements.txt` in GitHub and the built-in GitHub Actions workflow auto-builds and publishes a new image—no local Docker required. See the README for the detailed package list and CI steps.
 
 How to use it in JupyterHub:
 
 - Build or pull the image, then point your spawner at it, e.g. `c.DockerSpawner.image = "ghcr.io/your-org/custom-jupyterhub-docker-image:TAG"` (or the equivalent field for your spawner/Helm chart).
 - Restart JupyterHub so new servers launch with the custom image.
 
-Adopt it via GitHub templates: click “Use this template” to create your own copy (no fork history), tweak the Dockerfile or environment files, and push to your namespace to trigger the build.
+Adopt it via GitHub templates: click “Use this template” to create your own copy (no fork history), tweak `requirements.txt`, and push to your namespace to trigger the build.
 
 Where the image lives: the workflow can publish to GitHub Container Registry. Publish/pull docs: <https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry>.


### PR DESCRIPTION
Adds a short post outlining the custom JupyterHub Docker image template repo, how to set it in JupyterHub, use the GitHub template flow, and host images on GHCR.