### PR TITLE
Link JupyterHub posts to custom image template

### DIFF
--- a/posts/2023-10-27-jupyterhub-github-authentication.md
+++ b/posts/2023-10-27-jupyterhub-github-authentication.md
@@ -16,7 +16,7 @@ title: Deploy Github Authenticator in JupyterHub
 Quick reference on how to deploy the Github Authenticator in JupyterHub,
 the main reference is [the Zero to JupyterHub docs](https://z2jh.jupyter.org/en/latest/administrator/authentication.html#github).
 
-For maintaining the single-user image used by this setup, the easiest path is the custom template where you only update `requirements.txt` and let GitHub Actions rebuild and publish: {{< relref "posts/2025-12-01-custom-jupyterhub-docker-image.md" >}}.
+For maintaining the single-user image used by this setup, the easiest path is the custom template where you only update `requirements.txt` and let GitHub Actions rebuild and publish: <https://www.zonca.dev/posts/2025-12-01-custom-jupyterhub-docker-image.html>.
 
 First create a Oauth app on Github, see under "Settings" and "Developer options", set your Hub Callback url, see for example the configuration file below.
 

--- a/posts/2023-10-27-jupyterhub-github-authentication.md
+++ b/posts/2023-10-27-jupyterhub-github-authentication.md
@@ -16,7 +16,7 @@ title: Deploy Github Authenticator in JupyterHub
 Quick reference on how to deploy the Github Authenticator in JupyterHub,
 the main reference is [the Zero to JupyterHub docs](https://z2jh.jupyter.org/en/latest/administrator/authentication.html#github).
 
-For maintaining the single-user image used by this setup, the easiest path is the custom template where you only update `requirements.txt` and let GitHub Actions rebuild and publish: <https://www.zonca.dev/posts/2025-12-01-custom-jupyterhub-docker-image.html>.
+For maintaining the single-user image used by this setup, the easiest path is the custom template where you only update `requirements.txt` and let GitHub Actions rebuild and publish: {{< relref "posts/2025-12-01-custom-jupyterhub-docker-image.md" >}}.
 
 First create a Oauth app on Github, see under "Settings" and "Developer options", set your Hub Callback url, see for example the configuration file below.
 

--- a/posts/2023-10-27-jupyterhub-github-authentication.md
+++ b/posts/2023-10-27-jupyterhub-github-authentication.md
@@ -16,6 +16,8 @@ title: Deploy Github Authenticator in JupyterHub
 Quick reference on how to deploy the Github Authenticator in JupyterHub,
 the main reference is [the Zero to JupyterHub docs](https://z2jh.jupyter.org/en/latest/administrator/authentication.html#github).
 
+For maintaining the single-user image used by this setup, the easiest path is the custom template where you only update `requirements.txt` and let GitHub Actions rebuild and publish: {{< relref "posts/2025-12-01-custom-jupyterhub-docker-image.md" >}}.
+
 First create a Oauth app on Github, see under "Settings" and "Developer options", set your Hub Callback url, see for example the configuration file below.
 
 Save this configuration file as `config_github_auth.yaml` following [the template available on Github](https://github.com/zonca/jupyterhub-deploy-kubernetes-jetstream/blob/master/github/config_github.yaml)

--- a/posts/2023-10-27-jupyterhub-github-authentication.md
+++ b/posts/2023-10-27-jupyterhub-github-authentication.md
@@ -16,7 +16,7 @@ title: Deploy Github Authenticator in JupyterHub
 Quick reference on how to deploy the Github Authenticator in JupyterHub,
 the main reference is [the Zero to JupyterHub docs](https://z2jh.jupyter.org/en/latest/administrator/authentication.html#github).
 
-For maintaining the single-user image used by this setup, the easiest path is the custom template where you only update `requirements.txt` and let GitHub Actions rebuild and publish: {{< relref "posts/2025-12-01-custom-jupyterhub-docker-image.md" >}}.
+For maintaining the single-user image used by this setup, the easiest path is the custom template where you only update `requirements.txt` and let GitHub Actions rebuild and publish: {{< relref "2025-12-01-custom-jupyterhub-docker-image.md" >}}.
 
 First create a Oauth app on Github, see under "Settings" and "Developer options", set your Hub Callback url, see for example the configuration file below.
 

--- a/posts/2025-11-17-dask-operator-jupyterhub.md
+++ b/posts/2025-11-17-dask-operator-jupyterhub.md
@@ -155,6 +155,8 @@ I have created an example single-user image derived from `scipy-notebook` that i
 
 The list of available image tags is at [github.com/zonca/jupyterhub-dask-docker-image/pkgs/container/jupyterhub-dask-docker-image](https://github.com/zonca/jupyterhub-dask-docker-image/pkgs/container/jupyterhub-dask-docker-image).
 
+If you want the simplest maintenance flow for your own image, start from the custom template and just edit `requirements.txt`; a GitHub Actions workflow will rebuild and publish automatically: {{< relref "posts/2025-12-01-custom-jupyterhub-docker-image.md" >}}.
+
 To use one of these images in your JupyterHub deployment, you need to update your `config_standard_storage.yaml` file for the JupyterHub Helm chart. For example, to use a specific image tag, you would add:
 
 ```yaml

--- a/posts/2025-11-17-dask-operator-jupyterhub.md
+++ b/posts/2025-11-17-dask-operator-jupyterhub.md
@@ -155,7 +155,7 @@ I have created an example single-user image derived from `scipy-notebook` that i
 
 The list of available image tags is at [github.com/zonca/jupyterhub-dask-docker-image/pkgs/container/jupyterhub-dask-docker-image](https://github.com/zonca/jupyterhub-dask-docker-image/pkgs/container/jupyterhub-dask-docker-image).
 
-If you want the simplest maintenance flow for your own image, start from the custom template and just edit `requirements.txt`; a GitHub Actions workflow will rebuild and publish automatically: {{< relref "posts/2025-12-01-custom-jupyterhub-docker-image.md" >}}.
+If you want the simplest maintenance flow for your own image, start from the custom template and just edit `requirements.txt`; a GitHub Actions workflow will rebuild and publish automatically: {{< relref "2025-12-01-custom-jupyterhub-docker-image.md" >}}.
 
 To use one of these images in your JupyterHub deployment, you need to update your `config_standard_storage.yaml` file for the JupyterHub Helm chart. For example, to use a specific image tag, you would add:
 

--- a/posts/2025-11-17-dask-operator-jupyterhub.md
+++ b/posts/2025-11-17-dask-operator-jupyterhub.md
@@ -155,7 +155,7 @@ I have created an example single-user image derived from `scipy-notebook` that i
 
 The list of available image tags is at [github.com/zonca/jupyterhub-dask-docker-image/pkgs/container/jupyterhub-dask-docker-image](https://github.com/zonca/jupyterhub-dask-docker-image/pkgs/container/jupyterhub-dask-docker-image).
 
-If you want the simplest maintenance flow for your own image, start from the custom template and just edit `requirements.txt`; a GitHub Actions workflow will rebuild and publish automatically: <https://www.zonca.dev/posts/2025-12-01-custom-jupyterhub-docker-image.html>.
+If you want the simplest maintenance flow for your own image, start from the custom template and just edit `requirements.txt`; a GitHub Actions workflow will rebuild and publish automatically: {{< relref "posts/2025-12-01-custom-jupyterhub-docker-image.md" >}}.
 
 To use one of these images in your JupyterHub deployment, you need to update your `config_standard_storage.yaml` file for the JupyterHub Helm chart. For example, to use a specific image tag, you would add:
 

--- a/posts/2025-11-17-dask-operator-jupyterhub.md
+++ b/posts/2025-11-17-dask-operator-jupyterhub.md
@@ -155,7 +155,7 @@ I have created an example single-user image derived from `scipy-notebook` that i
 
 The list of available image tags is at [github.com/zonca/jupyterhub-dask-docker-image/pkgs/container/jupyterhub-dask-docker-image](https://github.com/zonca/jupyterhub-dask-docker-image/pkgs/container/jupyterhub-dask-docker-image).
 
-If you want the simplest maintenance flow for your own image, start from the custom template and just edit `requirements.txt`; a GitHub Actions workflow will rebuild and publish automatically: {{< relref "posts/2025-12-01-custom-jupyterhub-docker-image.md" >}}.
+If you want the simplest maintenance flow for your own image, start from the custom template and just edit `requirements.txt`; a GitHub Actions workflow will rebuild and publish automatically: <https://www.zonca.dev/posts/2025-12-01-custom-jupyterhub-docker-image.html>.
 
 To use one of these images in your JupyterHub deployment, you need to update your `config_standard_storage.yaml` file for the JupyterHub Helm chart. For example, to use a specific image tag, you would add:
 


### PR DESCRIPTION
Adds references to the custom JupyterHub single-user image template so readers know to update requirements.txt and let GitHub Actions rebuild the image.