### PR TITLE
Fix Crush config location in NRP post

### DIFF
--- a/posts/2026-01-29-configure-nrp-llm-opencode-crush.md
+++ b/posts/2026-01-29-configure-nrp-llm-opencode-crush.md
@@ -71,8 +71,8 @@ opencode run -m nrp/gpt-oss "Hello"
 To configure it for NRP, run this command:
 
 ```bash
-mkdir -p ~/.local/share/crush
-cat <<JSON > ~/.local/share/crush/crush.json
+mkdir -p ~/.config/crush
+cat <<JSON > ~/.config/crush/crush.json
 {
   "providers": {
     "nrp": {


### PR DESCRIPTION
Updated the configuration path for Crush from `~/.local/share/crush` to `~/.config/crush` in `posts/2026-01-29-configure-nrp-llm-opencode-crush.md` to match the official documentation and best practices.

---
*PR created automatically by Jules for task [17451859847170435420](https://jules.google.com/task/17451859847170435420) started by @zonca*