### PR TITLE
Cross-link NRP and Copilot AI Assistant posts

### DIFF
--- a/posts/2026-01-20-terminal-ai-assistant-github-education.md
+++ b/posts/2026-01-20-terminal-ai-assistant-github-education.md
@@ -56,3 +56,7 @@ You can use `/models` to choose a model. GitHub Copilot has free and premium mod
 For simpler tasks, the best unlimited model is **Grok Code Fast 1**, alternatively if you need a larger context you can use **GPT 4.1**.
 
 For more complicated tasks, the 2 best premium models are **GPT-5.2-codex** and **Gemini 3 pro**. You have 300 requests per month to these models.
+
+## Alternatives
+
+If you prefer to use the free NRP LLM service, check out [Configure NRP LLM with OpenCode and Crush](./2026-01-29-configure-nrp-llm-opencode-crush.md).

--- a/posts/2026-01-20-terminal-ai-assistant-github-education.md
+++ b/posts/2026-01-20-terminal-ai-assistant-github-education.md
@@ -59,4 +59,4 @@ For more complicated tasks, the 2 best premium models are **GPT-5.2-codex** and 
 
 ## Alternatives
 
-If you prefer to use the free NRP LLM service, check out [Configure NRP LLM with OpenCode and Crush](./2026-01-29-configure-nrp-llm-opencode-crush.md).
+If you prefer to use the free National Research Platform (NRP) LLM service, check out [Configure NRP LLM with OpenCode and Crush](./2026-01-29-configure-nrp-llm-opencode-crush.md).

--- a/posts/2026-01-29-configure-nrp-llm-opencode-crush.md
+++ b/posts/2026-01-29-configure-nrp-llm-opencode-crush.md
@@ -112,3 +112,7 @@ crush run -m nrp/glm-4.7 "Hello"
 ```
 
 You are now ready to use powerful open-source models for free in your terminal!
+
+## Alternatives
+
+If you have access to GitHub Copilot, you can also use these tools with it. See [Terminal-based AI Assistant with GitHub for Education](./2026-01-20-terminal-ai-assistant-github-education.md).


### PR DESCRIPTION
Added an "Alternatives" section to both "Configure NRP LLM with OpenCode and Crush" and "Terminal-based AI Assistant with GitHub for Education" posts to cross-link them as alternative solutions. Checked that links render correctly in the static site output.

---
*PR created automatically by Jules for task [14386857744978503162](https://jules.google.com/task/14386857744978503162) started by @zonca*