### PR TITLE
Update Crush link to charmbracelet/crush

### DIFF
--- a/posts/2026-01-29-configure-nrp-llm-opencode-crush.md
+++ b/posts/2026-01-29-configure-nrp-llm-opencode-crush.md
@@ -66,7 +66,7 @@ opencode run -m nrp/gpt-oss "Hello"
 
 ## Configure Crush
 
-[Crush](https://github.com/crush-sh/crush) is another excellent CLI tool.
+[Crush](https://github.com/charmbracelet/crush) is another excellent CLI tool.
 
 To configure it for NRP, run this command:
 


### PR DESCRIPTION
Updated the link for the Crush CLI tool in `posts/2026-01-29-configure-nrp-llm-opencode-crush.md` from `https://github.com/crush-sh/crush` to `https://github.com/charmbracelet/crush`.

---
*PR created automatically by Jules for task [1727740611157259686](https://jules.google.com/task/1727740611157259686) started by @zonca*