### PR TITLE
Mark kubespray deployment tutorial as obsolete

### DIFF
--- a/posts/2023-07-19-jetstream2_kubernetes_kubespray.md
+++ b/posts/2023-07-19-jetstream2_kubernetes_kubespray.md
@@ -9,6 +9,12 @@ title: Deploy Kubernetes on Jetstream 2 with Kubespray 2.21.0
 
 ---
 
+::: {.callout-note}
+**Obsolete Tutorial**
+
+This tutorial is obsolete. Please refer to the [Magnum tutorial](./2024-12-11-jetstream_kubernetes_magnum.md) to deploy Kubernetes instead.
+:::
+
 This work has been supported by Indiana University and is cross-posted on the <a href="https://docs.jetstream-cloud.org/general/k8skubespray/" rel="canonical">Jetstream 2 official documentation website</a>.
 
 This tutorial will explain how to install Kubernetes on Jetstream 2 relying on Kubespray.


### PR DESCRIPTION
Added a notice to the last kubespray blog post stating that it is obsolete and users should use Magnum instead. Provided a link to the latest Magnum tutorial.

---
*PR created automatically by Jules for task [7868303968517771715](https://jules.google.com/task/7868303968517771715) started by @zonca*