### PR TITLE
Add repo2docker-based JupyterHub image automation post

### DIFF
--- a/posts/2026-03-04-custom-jupyterhub-repo2docker-image.md
+++ b/posts/2026-03-04-custom-jupyterhub-repo2docker-image.md
@@ -7,36 +7,37 @@ layout: post
 title: Auto-build JupyterHub images with repo2docker and GitHub Actions
 ---
 
-Overview: Instead of maintaining a `Dockerfile`, you can build a JupyterHub-ready single-user image from repository configuration files (`environment.yml`, optional `postBuild`) using `repo2docker`. This keeps customization simple while still producing reproducible images for Zero to JupyterHub (Z2JH).
+Build and publish a JupyterHub-ready image directly from GitHub using `repo2docker`.
 
-Template repository: <https://github.com/zonca/custom-jupyterhub-repo2docker-image>
+Template repository: <https://github.com/zonca/custom-jupyterhub-repo2docker-image>  
+Latest integration run: <https://github.com/zonca/custom-jupyterhub-repo2docker-image/actions/runs/22652277154>
 
-Working CI example run: <https://github.com/zonca/custom-jupyterhub-repo2docker-image/actions/runs/22650073814>
+Quick start:
 
-How it works:
+1. Create your own repository from the template.
+2. Edit `environment.yml` with your packages.
+3. Push to `main`.
+4. Let GitHub Actions build and publish your image to GHCR.
 
-1. Edit `environment.yml` to add packages.
-2. Push to GitHub.
-3. GitHub Actions builds the image with `repo2docker`, runs JupyterHub smoke tests, and publishes to GHCR on `main`.
-4. The workflow signs images with Cosign, generates an SBOM, and attests build provenance.
+The workflow also signs images with Cosign, produces an SBOM, and adds build provenance.
 
-Suggested image tags:
-
-- `latest` for quick testing
-- `YYYY-MM-DD-<shortsha>` for reproducible JupyterHub deployments
-
-How to use in Z2JH (`config.yaml`):
+Use in Z2JH (`config.yaml`):
 
 ```yaml
 singleuser:
   image:
     name: ghcr.io/zonca/custom-jupyterhub-repo2docker-image
-    tag: 2026-03-04-c588129
+    tag: 2026-03-04-320a95e
   cmd: jupyterhub-singleuser
   defaultUrl: /lab
 ```
 
-Then deploy:
+Why set `cmd: jupyterhub-singleuser` explicitly:
+
+- It guarantees the pod starts the JupyterHub-aware server process.
+- It avoids image/entrypoint defaults that can leave pods running but not usable from Hub.
+
+Deploy:
 
 ```bash
 helm upgrade --install jhub jupyterhub/jupyterhub \
@@ -45,9 +46,12 @@ helm upgrade --install jhub jupyterhub/jupyterhub \
   --values config.yaml
 ```
 
-Why this is useful:
+Tagging strategy:
 
-- Lower maintenance than Dockerfiles for common scientific stacks
-- Fast iteration by editing only `environment.yml`
-- Security and provenance integrated into CI by default
-- Clear path from template repository to production JupyterHub image
+- `latest` for quick validation
+- `YYYY-MM-DD-<shortsha>` for reproducible production deploys
+
+CI flow:
+
+1. `image.yml`: build, test, push, sign, and attest.
+2. `z2jh-integration.yml`: run a real Hub test on Kind after a successful image workflow.

--- a/posts/2026-03-04-custom-jupyterhub-repo2docker-image.md
+++ b/posts/2026-03-04-custom-jupyterhub-repo2docker-image.md
@@ -9,8 +9,9 @@ title: Auto-build JupyterHub images with repo2docker and GitHub Actions
 
 Build and publish a JupyterHub-ready image directly from GitHub using `repo2docker`.
 
-Use this when you run a JupyterHub and need to update user environments often, for example for classes, workshops, or shared research platforms.
-Instead of hand-maintaining a full Dockerfile, you declare environment changes in repo2docker files and let CI build and validate the image automatically before you deploy it to Hub.
+The main goal is to update your JupyterHub software stack by editing `environment.yml` only.
+Use this when you run a JupyterHub and need frequent environment updates, for example for classes, workshops, or shared research platforms.
+Instead of hand-maintaining a full Dockerfile, you change the Conda environment file in Git and CI builds, validates, and publishes a new Hub-ready image tag.
 
 Template repository: <https://github.com/zonca/custom-jupyterhub-repo2docker-image>  
 Previous Dockerfile-based repository: <https://github.com/zonca/custom-jupyterhub-docker-image>  

--- a/posts/2026-03-04-custom-jupyterhub-repo2docker-image.md
+++ b/posts/2026-03-04-custom-jupyterhub-repo2docker-image.md
@@ -7,59 +7,76 @@ layout: post
 title: Auto-build JupyterHub images with repo2docker and GitHub Actions
 ---
 
-Build and publish a JupyterHub-ready image directly from GitHub using `repo2docker`.
+*This guide explains how to automatically build a custom, JupyterHub-ready Docker image directly from GitHub using `repo2docker`, without having to write a complicated Dockerfile from scratch.*
 
-The main goal is to update your JupyterHub software stack by editing `environment.yml` only.
-Use this when you run a JupyterHub and need frequent environment updates, for example for classes, workshops, or shared research platforms.
-Instead of hand-maintaining a full Dockerfile, you change the Conda environment file in Git and CI builds, validates, and publishes a new Hub-ready image tag.
+### The Problem
 
-Template repository: <https://github.com/zonca/custom-jupyterhub-repo2docker-image>  
-Previous Dockerfile-based repository: <https://github.com/zonca/custom-jupyterhub-docker-image>  
-Latest integration run: <https://github.com/zonca/custom-jupyterhub-repo2docker-image/actions/runs/22652277154>
+If you run a JupyterHub—whether it's for a university class, a workshop, or a shared research platform—your users will need specific Python packages installed. 
 
-How this differs from the Dockerfile approach:
+Usually, customizing this software stack means writing a full `Dockerfile` by hand. Writing Dockerfiles can be complex, and maintaining them over time as packages change requires specialized knowledge of Docker commands and Linux server administration.
 
-- With the Dockerfile repo, most customization happens in `Dockerfile` layers.
-- With this repo2docker template, most customization happens in `environment.yml` (and optional `postBuild`).
-- Dockerfiles give maximum low-level control; repo2docker reduces maintenance for standard scientific Python environments.
-- This template also adds a separate Z2JH integration workflow that runs after image build to validate real JupyterHub startup.
+### The Solution: repo2docker
 
-repo2docker files used in this workflow:
+Instead of writing a `Dockerfile` from scratch, we can use a tool created by the Jupyter project called [repo2docker](https://repo2docker.readthedocs.io/). 
 
-- `environment.yml`: Conda environment definition (packages/channels).
-- `requirements.txt`: Optional pip packages.
-- `apt.txt`: Optional Ubuntu packages installed with `apt`.
-- `postBuild`: Optional build-time shell script (compile assets, install extras).
-- `start`: Optional runtime startup script.
+The goal of `repo2docker` is simple: it looks at standard configuration files (like `environment.yml` for Conda, or `requirements.txt` for pip) and automatically turns them into a fully functional Docker image. 
 
-In short: edit these files in Git, push, and CI produces a JupyterHub-usable image tag for your Helm config.
+With this approach, **you only need to update your list of packages in GitHub, and "Continuous Integration" (CI) pipelines will automatically build, test, and publish a new image ready for your JupyterHub.**
 
-Quick start:
+### Using the Template Repository
 
-1. Create your own repository from the template.
-2. Edit `environment.yml` with your packages.
-3. Push to `main`.
-4. Let GitHub Actions build and publish your image to GHCR.
+To make this as easy as possible, I have created a template repository that has everything set up for you:
 
-The workflow also signs images with Cosign, produces an SBOM, and adds build provenance.
+*   **Template repository:** <https://github.com/zonca/custom-jupyterhub-repo2docker-image>  
+*   **Previous Dockerfile-based repository:** <https://github.com/zonca/custom-jupyterhub-docker-image> *(for comparison)*
+*   **Latest integration run:** <https://github.com/zonca/custom-jupyterhub-repo2docker-image/actions/runs/22652277154>
 
-Use in Z2JH (`config.yaml`):
+#### How this differs from the traditional Dockerfile approach
+
+*   **Dockerfile approach:** You have maximum control over the environment, but you spend your time managing lower-level server details inside Docker layers.
+*   **repo2docker approach:** You spend your time specifying scientific packages in an `environment.yml` file. It drastically reduces maintenance, especially for standard scientific Python environments.
+
+#### The configuration files
+
+When using this template, you'll mainly interact with these simple files:
+
+*   `environment.yml`: The main Conda environment definition (for your Python packages and channels).
+*   `requirements.txt`: Optional pip packages.
+*   `apt.txt`: Optional Ubuntu system packages installed with `apt`.
+*   `postBuild`: An optional shell script for anything that needs to be compiled or run after packages are installed.
+*   `start`: An optional script that runs when the server starts up.
+
+### Quick Start Guide
+
+Here is all you need to do to get your custom JupyterHub image building:
+
+1.  **Create your repository:** Go to the [template repository](https://github.com/zonca/custom-jupyterhub-repo2docker-image) and click the "Use this template" button to create your own copy on GitHub.
+2.  **Add your packages:** Edit the `environment.yml` file in your new repository to include the software your users need.
+3.  **Save your changes:** Commit and push these changes to the `main` branch.
+4.  **Automatic Build:** GitHub Actions will automatically detect the changes, build the image, and publish it securely to the GitHub Container Registry (GHCR). 
+
+*Security bonus: The automated workflow also digitally signs the images with Cosign and produces security artifacts (SBOMs) to ensure your supply chain is secure.*
+
+### Deploying Your Image to JupyterHub
+
+Once GitHub Actions successfully builds your image, you can tell your JupyterHub (which typically runs on Kubernetes using Zero to JupyterHub / Z2JH) to start using it. 
+
+You configure this in your JupyterHub `config.yaml` file:
 
 ```yaml
 singleuser:
   image:
-    name: ghcr.io/zonca/custom-jupyterhub-repo2docker-image
+    name: ghcr.io/YOUR_GITHUB_USERNAME/custom-jupyterhub-repo2docker-image
     tag: 2026-03-04-320a95e
   cmd: jupyterhub-singleuser
   defaultUrl: /lab
 ```
 
-Why set `cmd: jupyterhub-singleuser` explicitly:
+*Note on Tags:* GitHub automatically creates unique tags based on the date and a short commit code (e.g., `2026-03-04-320a95e`). This guarantees you are running the exact version you just built. Avoid using the `latest` tag in production environments!
 
-- It guarantees the pod starts the JupyterHub-aware server process.
-- It avoids image/entrypoint defaults that can leave pods running but not usable from Hub.
+*Note on the `cmd` setting:* We explicitly set `cmd: jupyterhub-singleuser`. This guarantees the pod correctly starts the JupyterHub-aware server process and prevents any default settings from leaving the pod running but unusable from the Hub.
 
-Deploy:
+Finally, deploy the updated configuration using Helm:
 
 ```bash
 helm upgrade --install jhub jupyterhub/jupyterhub \
@@ -68,12 +85,8 @@ helm upgrade --install jhub jupyterhub/jupyterhub \
   --values config.yaml
 ```
 
-Tagging strategy:
+### Advanced Automated Testing
 
-- `latest` for quick validation
-- `YYYY-MM-DD-<shortsha>` for reproducible production deploys
+To make sure you never accidentally publish a broken image, the template includes a real-world integration test. 
 
-CI flow:
-
-1. `image.yml`: build, test, push, sign, and attest.
-2. `z2jh-integration.yml`: run a real Hub test on Kind after a successful image workflow.
+After your new image is built, a separate GitHub workflow (`z2jh-integration.yml`) spins up a miniature Kubernetes cluster using `kind`, installs JupyterHub, and actually makes sure a real Hub can start up using your successfully built image workflow!

--- a/posts/2026-03-04-custom-jupyterhub-repo2docker-image.md
+++ b/posts/2026-03-04-custom-jupyterhub-repo2docker-image.md
@@ -9,8 +9,19 @@ title: Auto-build JupyterHub images with repo2docker and GitHub Actions
 
 Build and publish a JupyterHub-ready image directly from GitHub using `repo2docker`.
 
+This post shows a lightweight path from package configuration files to a production-ready JupyterHub image.
+The goal is to keep customization simple while still getting reproducible builds, security metadata, and an end-to-end integration test that verifies the image actually works in Hub.
+
 Template repository: <https://github.com/zonca/custom-jupyterhub-repo2docker-image>  
+Previous Dockerfile-based repository: <https://github.com/zonca/custom-jupyterhub-docker-image>  
 Latest integration run: <https://github.com/zonca/custom-jupyterhub-repo2docker-image/actions/runs/22652277154>
+
+How this differs from the Dockerfile approach:
+
+- With the Dockerfile repo, most customization happens in `Dockerfile` layers.
+- With this repo2docker template, most customization happens in `environment.yml` (and optional `postBuild`).
+- Dockerfiles give maximum low-level control; repo2docker reduces maintenance for standard scientific Python environments.
+- This template also adds a separate Z2JH integration workflow that runs after image build to validate real JupyterHub startup.
 
 Quick start:
 

--- a/posts/2026-03-04-custom-jupyterhub-repo2docker-image.md
+++ b/posts/2026-03-04-custom-jupyterhub-repo2docker-image.md
@@ -1,0 +1,53 @@
+---
+categories:
+- jupyterhub
+- python
+date: '2026-03-04'
+layout: post
+title: Auto-build JupyterHub images with repo2docker and GitHub Actions
+---
+
+Overview: Instead of maintaining a `Dockerfile`, you can build a JupyterHub-ready single-user image from repository configuration files (`environment.yml`, optional `postBuild`) using `repo2docker`. This keeps customization simple while still producing reproducible images for Zero to JupyterHub (Z2JH).
+
+Template repository: <https://github.com/zonca/custom-jupyterhub-repo2docker-image>
+
+Working CI example run: <https://github.com/zonca/custom-jupyterhub-repo2docker-image/actions/runs/22650073814>
+
+How it works:
+
+1. Edit `environment.yml` to add packages.
+2. Push to GitHub.
+3. GitHub Actions builds the image with `repo2docker`, runs JupyterHub smoke tests, and publishes to GHCR on `main`.
+4. The workflow signs images with Cosign, generates an SBOM, and attests build provenance.
+
+Suggested image tags:
+
+- `latest` for quick testing
+- `YYYY-MM-DD-<shortsha>` for reproducible JupyterHub deployments
+
+How to use in Z2JH (`config.yaml`):
+
+```yaml
+singleuser:
+  image:
+    name: ghcr.io/zonca/custom-jupyterhub-repo2docker-image
+    tag: 2026-03-04-c588129
+  cmd: jupyterhub-singleuser
+  defaultUrl: /lab
+```
+
+Then deploy:
+
+```bash
+helm upgrade --install jhub jupyterhub/jupyterhub \
+  --namespace jhub \
+  --create-namespace \
+  --values config.yaml
+```
+
+Why this is useful:
+
+- Lower maintenance than Dockerfiles for common scientific stacks
+- Fast iteration by editing only `environment.yml`
+- Security and provenance integrated into CI by default
+- Clear path from template repository to production JupyterHub image

--- a/posts/2026-03-04-custom-jupyterhub-repo2docker-image.md
+++ b/posts/2026-03-04-custom-jupyterhub-repo2docker-image.md
@@ -9,8 +9,8 @@ title: Auto-build JupyterHub images with repo2docker and GitHub Actions
 
 Build and publish a JupyterHub-ready image directly from GitHub using `repo2docker`.
 
-This post shows a lightweight path from package configuration files to a production-ready JupyterHub image.
-The goal is to keep customization simple while still getting reproducible builds, security metadata, and an end-to-end integration test that verifies the image actually works in Hub.
+Use this when you run a JupyterHub and need to update user environments often, for example for classes, workshops, or shared research platforms.
+Instead of hand-maintaining a full Dockerfile, you declare environment changes in repo2docker files and let CI build and validate the image automatically before you deploy it to Hub.
 
 Template repository: <https://github.com/zonca/custom-jupyterhub-repo2docker-image>  
 Previous Dockerfile-based repository: <https://github.com/zonca/custom-jupyterhub-docker-image>  
@@ -22,6 +22,16 @@ How this differs from the Dockerfile approach:
 - With this repo2docker template, most customization happens in `environment.yml` (and optional `postBuild`).
 - Dockerfiles give maximum low-level control; repo2docker reduces maintenance for standard scientific Python environments.
 - This template also adds a separate Z2JH integration workflow that runs after image build to validate real JupyterHub startup.
+
+repo2docker files used in this workflow:
+
+- `environment.yml`: Conda environment definition (packages/channels).
+- `requirements.txt`: Optional pip packages.
+- `apt.txt`: Optional Ubuntu packages installed with `apt`.
+- `postBuild`: Optional build-time shell script (compile assets, install extras).
+- `start`: Optional runtime startup script.
+
+In short: edit these files in Git, push, and CI produces a JupyterHub-usable image tag for your Helm config.
 
 Quick start:
 


### PR DESCRIPTION
## Summary
- add a new blog post on building JupyterHub images with `repo2docker` and GitHub Actions
- include the live template repository link: https://github.com/zonca/custom-jupyterhub-repo2docker-image
- include a successful CI run link and Z2JH configuration snippet

## Context
This is the new version of the 2025-12-01 custom JupyterHub image post, updated to a `repo2docker` workflow instead of a `Dockerfile` workflow.
