### PR TITLE
docs(blog): make repo2docker post beginner-friendly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: list
+.PHONY: all list publish pull render clean
 
 all: pull render publish
 
@@ -17,3 +17,9 @@ pull:
 
 render:
 	quarto render
+
+clean:
+	rm -rf .quarto _site site_libs
+	rm -f ./*.html ./index-listing.json
+	rm -f ./posts/*.html ./posts/*.out.ipynb
+	rm -rf ./posts/*_files

--- a/posts/2023-07-19-jetstream2_kubernetes_kubespray.md
+++ b/posts/2023-07-19-jetstream2_kubernetes_kubespray.md
@@ -9,6 +9,12 @@ title: Deploy Kubernetes on Jetstream 2 with Kubespray 2.21.0
 
 ---
 
+::: {.callout-note}
+**Obsolete Tutorial**
+
+This tutorial is obsolete. Please refer to the [Magnum tutorial](./2024-12-11-jetstream_kubernetes_magnum.md) to deploy Kubernetes instead.
+:::
+
 This work has been supported by Indiana University and is cross-posted on the <a href="https://docs.jetstream-cloud.org/general/k8skubespray/" rel="canonical">Jetstream 2 official documentation website</a>.
 
 This tutorial will explain how to install Kubernetes on Jetstream 2 relying on Kubespray.

--- a/posts/2026-01-29-configure-nrp-llm-opencode-crush.md
+++ b/posts/2026-01-29-configure-nrp-llm-opencode-crush.md
@@ -66,7 +66,7 @@ opencode run -m nrp/gpt-oss "Hello"
 
 ## Configure Crush
 
-[Crush](https://github.com/crush-sh/crush) is another excellent CLI tool.
+[Crush](https://github.com/charmbracelet/crush) is another excellent CLI tool.
 
 To configure it for NRP, run this command:
 

--- a/posts/2026-03-03-nbgrader-manila-exchange-jetstream.md
+++ b/posts/2026-03-03-nbgrader-manila-exchange-jetstream.md
@@ -1,0 +1,246 @@
+---
+categories:
+- kubernetes
+- jetstream
+- jupyterhub
+- nbgrader
+date: '2026-03-03'
+layout: post
+title: Deploy nbgrader on Jetstream with a Manila exchange disk (Kubernetes)
+---
+
+This tutorial shows how to deploy **nbgrader** on Jetstream Kubernetes using a **shared Manila disk** mounted on all JupyterHub user pods.
+
+This is for the setup where:
+
+* You already created a Magnum cluster named `k8s`.
+* You already created a Jetstream-managed Manila share named `nbgraderexchange` (via Exosphere).
+* You want nbgrader's default **filesystem exchange** (no `ngshare`).
+
+We will:
+
+* Configure `kubectl` for the Magnum cluster.
+* Mount the existing Manila share into all JupyterHub user pods at `/share`.
+* Configure nbgrader to use `/share/nbgrader/exchange`.
+* Run the full instructor/student workflow (`release`, `fetch`, `submit`, `collect`, `autograde`).
+
+## Why this approach
+
+nbgrader's native exchange expects a shared filesystem visible from both instructor and student pods.  
+A Manila share mounted as `ReadWriteMany` provides exactly that.
+
+## Prerequisites
+
+* A running Magnum cluster named `k8s`.
+* JupyterHub deployed with Helm.
+* A Manila share already created.
+* This repository cloned locally.
+* OpenStack credentials (`*openrc*.sh`) and local `.venv` available.
+
+## Step 1: Configure access to the Magnum cluster
+
+From the repo root:
+
+```bash
+source ./app-cred-coe-202504-openrc.sh
+source .venv/bin/activate
+export K8S_CLUSTER_NAME=k8s
+bash kubernetes_magnum/configure_kubectl_locally.sh
+export KUBECONFIG=$(pwd)/config
+kubectl get nodes
+```
+
+You should see nodes from your `k8s` cluster.
+
+## Step 2: Prepare the existing Manila share as a Kubernetes RWX volume
+
+This repo includes templates for Jetstream Manila CephFS:
+
+* `manila/cephfs-csi-values.yaml`
+* `manila/cephfs-csi-pv.yaml`
+* `manila/cephfs-csi-pvc.yaml`
+
+Get mount info from the existing Exosphere share:
+
+```bash
+bash manila/generate_mount_command.sh nbgraderexchange
+```
+
+Use the output to fill placeholders in `manila/cephfs-csi-values.yaml` and `manila/cephfs-csi-pv.yaml`:
+
+* `<CEPH_FSID>` (any stable ID string is fine, but it must match in both files)
+* `<ACCESS_RULE_NAME>`
+* `<ACCESS_KEY>`
+* `<SHARE_PATH>` as **path only** (`/volumes/...`), not the full `mon1,mon2:/volumes/...` string
+
+Install CephFS CSI (if not already installed) and create PV/PVC:
+
+```bash
+helm repo add ceph-csi https://ceph.github.io/csi-charts/ || true
+helm repo update
+helm upgrade --install ceph-csi-cephfs ceph-csi/ceph-csi-cephfs \
+  --namespace kube-system \
+  -f manila/cephfs-csi-values.yaml
+
+kubectl create namespace jhub --dry-run=client -o yaml | kubectl apply -f -
+kubectl apply -f manila/cephfs-csi-pv.yaml
+kubectl apply -f manila/cephfs-csi-pvc.yaml
+kubectl -n jhub get pvc manila-cephfs
+```
+
+Important for `manila/cephfs-csi-pv.yaml`:
+
+* Add `fsName: "cephfs"` under `volumeAttributes`.
+* Keep `clusterID` aligned with `manila/cephfs-csi-values.yaml`.
+* Ensure `nodeStageSecretRef.namespace` matches where `csi-cephfs-secret` exists.
+
+If the chart created `csi-cephfs-secret` in `kube-system` but your PV references `default`, copy it once:
+
+```bash
+kubectl -n kube-system get secret csi-cephfs-secret -o yaml \
+  | sed 's/namespace: kube-system/namespace: default/' \
+  | kubectl apply -f -
+```
+
+Expected PVC status:
+
+```
+NAME            STATUS   VOLUME             CAPACITY   ACCESS MODES
+manila-cephfs   Bound    manila-cephfs-pv   50Gi       RWX
+```
+
+## Step 3: Mount the Manila share in all JupyterHub user pods
+
+Use the values file already in this repo:
+
+* `manila/jupyterhub_manila.yaml`
+
+It mounts the shared PVC at `/share` for every user pod.
+
+Verify JupyterHub exists in `jhub` namespace:
+
+```bash
+helm list -n jhub
+```
+
+If no `jhub` release is present yet, deploy JupyterHub first, then continue.
+
+Add this values file to `install_jhub.sh` (before the last line):
+
+```
+--values manila/jupyterhub_manila.yaml \
+```
+
+Re-deploy:
+
+```bash
+bash install_jhub.sh
+```
+
+## Step 4: Install nbgrader and configure filesystem exchange
+
+Use this file from the repo:
+
+* `nbgrader/jhub-singleuser-nbgrader-filesystem.yaml`
+
+Replace `COURSE_ID` with your course ID (example: `course101`).
+
+Add this file to `install_jhub.sh`:
+
+```
+--values nbgrader/jhub-singleuser-nbgrader-filesystem.yaml \
+```
+
+Re-deploy:
+
+```bash
+bash install_jhub.sh
+```
+
+## Step 5: Validate the shared mount and initialize exchange folders
+
+Open a JupyterHub terminal as an instructor/admin user:
+
+```bash
+python -m pip show nbgrader
+mkdir -p /share/nbgrader/exchange
+mkdir -p /share/nbgrader/exchange/course101/{inbound,outbound,feedback}
+chmod -R 0777 /share/nbgrader/exchange
+ls -la /share/nbgrader/exchange/course101
+```
+
+If `/share` is mounted but writing fails with `Permission denied`, run a one-time permission bootstrap pod:
+
+```bash
+kubectl -n jhub apply -f nbgrader/manila-exchange-permissions-pod.yaml
+kubectl -n jhub logs manila-exchange-permissions
+kubectl -n jhub delete pod manila-exchange-permissions
+```
+
+Then open a different user server and confirm the same files are visible:
+
+```bash
+ls -la /share/nbgrader/exchange/course101
+```
+
+## Step 6: Instructor workflow (create + release)
+
+As instructor:
+
+```bash
+nbgrader quickstart course101
+cp -r /path/to/jupyterhub-deploy-kubernetes-jetstream/nbgrader/quickstart-source/ps1 /home/jovyan/course101/source/
+cd /home/jovyan/course101
+nbgrader generate_assignment ps1 --force
+nbgrader db student add student1
+nbgrader release_assignment ps1 --force
+```
+
+## Step 7: Student workflow (list + fetch + submit)
+
+As `student1`:
+
+```bash
+nbgrader list
+nbgrader fetch_assignment ps1
+nbgrader submit ps1
+```
+
+Expected output includes `course101 ps1` in `nbgrader list` and a successful submit message.
+
+## Step 8: Instructor workflow (collect + autograde)
+
+As instructor:
+
+```bash
+cd /home/jovyan/course101
+nbgrader collect ps1
+nbgrader autograde ps1
+```
+
+## Notes
+
+* This tutorial uses nbgrader's **filesystem exchange** on a shared Manila disk.
+* No `ngshare` service or `ngshare_exchange` package is required.
+* The important part is that all user pods mount the same RWX path and permissions allow read/write for instructor and students.
+
+## Troubleshooting
+
+If `nbgrader fetch_assignment` or `submit` fails with permission errors:
+
+```bash
+chmod -R 0777 /share/nbgrader/exchange
+```
+
+If user pods don't see `/share`, confirm both values files were included in `install_jhub.sh` and run `bash install_jhub.sh` again.
+
+If the Manila PVC is not `Bound`, re-check placeholders in:
+
+* `manila/cephfs-csi-values.yaml`
+* `manila/cephfs-csi-pv.yaml`
+
+If pods are stuck in `ContainerCreating` with Ceph mount errors:
+
+* `missing required field fsName`: add `fsName: "cephfs"` in `manila/cephfs-csi-pv.yaml`.
+* `mount error 3 = No such process`: `rootPath` is wrong; use only `/volumes/...` path.
+* `failed to find the secret csi-cephfs-secret in namespace default`: align `nodeStageSecretRef.namespace` with the namespace where the secret exists.

--- a/posts/2026-03-03-nbgrader-manila-exchange-jetstream.md
+++ b/posts/2026-03-03-nbgrader-manila-exchange-jetstream.md
@@ -137,6 +137,8 @@ Re-deploy:
 bash install_jhub.sh
 ```
 
+Then stop and start existing user servers so they pick up the new mount.
+
 ## Step 4: Install nbgrader and configure filesystem exchange
 
 Use this file from the repo:
@@ -157,6 +159,8 @@ Re-deploy:
 bash install_jhub.sh
 ```
 
+Then stop and start existing user servers so the `postStart` hook re-runs and writes the updated `nbgrader_config.py`.
+
 ## Step 5: Validate the shared mount and initialize exchange folders
 
 Open a JupyterHub terminal as an instructor/admin user:
@@ -164,7 +168,9 @@ Open a JupyterHub terminal as an instructor/admin user:
 ```bash
 python -m pip show nbgrader
 mkdir -p /share/nbgrader/exchange
-mkdir -p /share/nbgrader/exchange/course101/{inbound,outbound,feedback}
+mkdir -p /share/nbgrader/exchange/course101/inbound
+mkdir -p /share/nbgrader/exchange/course101/outbound
+mkdir -p /share/nbgrader/exchange/course101/feedback
 chmod -R 0777 /share/nbgrader/exchange
 ls -la /share/nbgrader/exchange/course101
 ```
@@ -203,7 +209,7 @@ As `student1`:
 ```bash
 nbgrader list
 nbgrader fetch_assignment ps1
-nbgrader submit ps1
+nbgrader submit /home/jovyan/course101/ps1
 ```
 
 Expected output includes `course101 ps1` in `nbgrader list` and a successful submit message.

--- a/posts/2026-03-03-nbgrader-manila-exchange-jetstream.md
+++ b/posts/2026-03-03-nbgrader-manila-exchange-jetstream.md
@@ -245,38 +245,24 @@ ls -la /share/nbgrader/exchange/course101
 
 ## Step 8: Instructor workflow (create + release)
 
-As instructor:
+From this point, the nbgrader workflow is the same as in the previous tutorial:
 
-```bash
-nbgrader quickstart course101
-cp -r /path/to/jupyterhub-deploy-kubernetes-jetstream/nbgrader/quickstart-source/ps1 /home/jovyan/course101/source/
-cd /home/jovyan/course101
-nbgrader generate_assignment ps1 --force
-nbgrader db student add student1
-nbgrader release_assignment ps1 --force
-```
+* Create/release: [`./2026-02-04-nbgrader-ngshare-jetstream.md#step-6-create-and-release-a-first-assignment`](./2026-02-04-nbgrader-ngshare-jetstream.md#step-6-create-and-release-a-first-assignment)
+* Student fetch/submit: [`./2026-02-04-nbgrader-ngshare-jetstream.md#step-7-student-workflow-fetch--submit`](./2026-02-04-nbgrader-ngshare-jetstream.md#step-7-student-workflow-fetch--submit)
+* Instructor collect/autograde: [`./2026-02-04-nbgrader-ngshare-jetstream.md#step-8-instructor-workflow-collect--autograde`](./2026-02-04-nbgrader-ngshare-jetstream.md#step-8-instructor-workflow-collect--autograde)
+
+Manila-specific difference:
+
+* You do **not** need `ngshare-course-management`.
+* Student roster is managed with `nbgrader db student add ...` on the instructor side.
 
 ## Step 9: Student workflow (list + fetch + submit)
 
-As `student1`:
-
-```bash
-nbgrader list
-nbgrader fetch_assignment ps1
-nbgrader submit /home/jovyan/course101/ps1
-```
-
-Expected output includes `course101 ps1` in `nbgrader list` and a successful submit message.
+Use the same commands as linked in Step 8.
 
 ## Step 10: Instructor workflow (collect + autograde)
 
-As instructor:
-
-```bash
-cd /home/jovyan/course101
-nbgrader collect ps1
-nbgrader autograde ps1
-```
+Use the same commands as linked in Step 8.
 
 ## Notes
 

--- a/posts/2026-03-03-nbgrader-manila-exchange-jetstream.md
+++ b/posts/2026-03-03-nbgrader-manila-exchange-jetstream.md
@@ -63,8 +63,8 @@ You can create it in **Exosphere** (recommended), or via OpenStack CLI.
 Example CLI flow:
 
 ```bash
-# Load credentials first
-source /path/to/your-openrc.sh
+# First ensure your shell already has OpenStack credentials loaded.
+# Also ensure openstack/kubectl/helm are available in your current environment.
 
 # Create a 50 GiB CephFS share
 openstack share create \
@@ -90,13 +90,8 @@ Note: in this workflow, Kubernetes mounts the Manila share through CephFS CSI, b
 From the repo root:
 
 ```bash
-# Load your OpenStack credentials
-source /path/to/your-openrc.sh
-
-# Activate the environment where openstack/kubectl/helm are available
-# (conda env, virtualenv, module environment, etc.)
-# Example:
-# source /path/to/your/env/bin/activate
+# Ensure your current shell already has OpenStack credentials loaded
+# and has openstack/kubectl/helm available.
 
 export K8S_CLUSTER_NAME=k8s
 bash kubernetes_magnum/configure_kubectl_locally.sh

--- a/posts/2026-03-03-nbgrader-manila-exchange-jetstream.md
+++ b/posts/2026-03-03-nbgrader-manila-exchange-jetstream.md
@@ -40,12 +40,12 @@ A Manila share mounted as `ReadWriteMany` provides exactly that.
 
 * A running Magnum cluster named `k8s`.
 * JupyterHub deployed with Helm.
-* A Manila share already created (or created in Step 0 below).
+* A Manila share already created (or created in Step 2 below).
 * OpenStack credentials file (`*openrc*.sh`) available.
 * A shell environment where required CLIs are installed and configured:
   `openstack`, `kubectl`, and `helm`.
 
-## Step -1: Check out this repository
+## Step 1: Check out this repository
 
 This tutorial uses config files from this repo (`manila/`, `nbgrader/`, `config_*.yaml`, etc.), so clone it first:
 
@@ -54,7 +54,7 @@ git clone https://github.com/zonca/jupyterhub-deploy-kubernetes-jetstream.git
 cd jupyterhub-deploy-kubernetes-jetstream
 ```
 
-## Step 0 (if needed): Create the Manila share
+## Step 2 (if needed): Create the Manila share
 
 This tutorial uses an existing Jetstream Manila share named `nbgraderexchange`.
 
@@ -85,7 +85,7 @@ openstack share access list nbgraderexchange
 
 Note: in this workflow, Kubernetes mounts the Manila share through CephFS CSI, but does not create the Manila share itself.
 
-## Step 1: Configure access to the Magnum cluster
+## Step 3: Configure access to the Magnum cluster
 
 From the repo root:
 
@@ -106,7 +106,7 @@ kubectl get nodes
 
 You should see nodes from your `k8s` cluster.
 
-## Step 2: Prepare the existing Manila share as a Kubernetes RWX volume
+## Step 4: Prepare the existing Manila share as a Kubernetes RWX volume
 
 This repo includes templates for Jetstream Manila CephFS:
 
@@ -163,7 +163,7 @@ NAME            STATUS   VOLUME             CAPACITY   ACCESS MODES
 manila-cephfs   Bound    manila-cephfs-pv   50Gi       RWX
 ```
 
-## Step 3: Mount the Manila share in all JupyterHub user pods
+## Step 5: Mount the Manila share in all JupyterHub user pods
 
 Use the values file already in this repo:
 
@@ -193,7 +193,7 @@ bash install_jhub.sh
 
 Then stop and start existing user servers so they pick up the new mount.
 
-## Step 4: Install nbgrader and configure filesystem exchange
+## Step 6: Install nbgrader and configure filesystem exchange
 
 Use this file from the repo:
 
@@ -215,7 +215,7 @@ bash install_jhub.sh
 
 Then stop and start existing user servers so the `postStart` hook re-runs and writes the updated `nbgrader_config.py`.
 
-## Step 5: Validate the shared mount and initialize exchange folders
+## Step 7: Validate the shared mount and initialize exchange folders
 
 Open a JupyterHub terminal as an instructor/admin user:
 
@@ -243,7 +243,7 @@ Then open a different user server and confirm the same files are visible:
 ls -la /share/nbgrader/exchange/course101
 ```
 
-## Step 6: Instructor workflow (create + release)
+## Step 8: Instructor workflow (create + release)
 
 As instructor:
 
@@ -256,7 +256,7 @@ nbgrader db student add student1
 nbgrader release_assignment ps1 --force
 ```
 
-## Step 7: Student workflow (list + fetch + submit)
+## Step 9: Student workflow (list + fetch + submit)
 
 As `student1`:
 
@@ -268,7 +268,7 @@ nbgrader submit /home/jovyan/course101/ps1
 
 Expected output includes `course101 ps1` in `nbgrader list` and a successful submit message.
 
-## Step 8: Instructor workflow (collect + autograde)
+## Step 10: Instructor workflow (collect + autograde)
 
 As instructor:
 

--- a/posts/2026-03-03-nbgrader-manila-exchange-jetstream.md
+++ b/posts/2026-03-03-nbgrader-manila-exchange-jetstream.md
@@ -19,10 +19,17 @@ This is for the setup where:
 
 We will:
 
+* Check out this repository locally (contains all config files used below).
 * Configure `kubectl` for the Magnum cluster.
 * Mount the existing Manila share into all JupyterHub user pods at `/share`.
 * Configure nbgrader to use `/share/nbgrader/exchange`.
 * Run the full instructor/student workflow (`release`, `fetch`, `submit`, `collect`, `autograde`).
+
+If you want the API-based approach instead of a shared disk, see the previous tutorial:
+[`./2026-02-04-nbgrader-ngshare-jetstream.md`](./2026-02-04-nbgrader-ngshare-jetstream.md)
+
+Difference in one line:
+this tutorial uses nbgrader's native filesystem exchange on a Manila RWX share, while the previous tutorial uses `ngshare` (REST API exchange without shared filesystem).
 
 ## Why this approach
 
@@ -33,17 +40,64 @@ A Manila share mounted as `ReadWriteMany` provides exactly that.
 
 * A running Magnum cluster named `k8s`.
 * JupyterHub deployed with Helm.
-* A Manila share already created.
-* This repository cloned locally.
-* OpenStack credentials (`*openrc*.sh`) and local `.venv` available.
+* A Manila share already created (or created in Step 0 below).
+* OpenStack credentials file (`*openrc*.sh`) available.
+* A shell environment where required CLIs are installed and configured:
+  `openstack`, `kubectl`, and `helm`.
+
+## Step -1: Check out this repository
+
+This tutorial uses config files from this repo (`manila/`, `nbgrader/`, `config_*.yaml`, etc.), so clone it first:
+
+```bash
+git clone https://github.com/zonca/jupyterhub-deploy-kubernetes-jetstream.git
+cd jupyterhub-deploy-kubernetes-jetstream
+```
+
+## Step 0 (if needed): Create the Manila share
+
+This tutorial uses an existing Jetstream Manila share named `nbgraderexchange`.
+
+You can create it in **Exosphere** (recommended), or via OpenStack CLI.
+
+Example CLI flow:
+
+```bash
+# Load credentials first
+source /path/to/your-openrc.sh
+
+# Create a 50 GiB CephFS share
+openstack share create \
+  --name nbgraderexchange \
+  --share-type cephfsnativetype \
+  --share-protocol CEPHFS \
+  50
+
+# Create a CephX RW access rule
+openstack share access create \
+  --access-level rw \
+  nbgraderexchange cephx nbgraderexchange-rw
+
+# Verify
+openstack share list --name nbgraderexchange
+openstack share access list nbgraderexchange
+```
+
+Note: in this workflow, Kubernetes mounts the Manila share through CephFS CSI, but does not create the Manila share itself.
 
 ## Step 1: Configure access to the Magnum cluster
 
 From the repo root:
 
 ```bash
-source ./app-cred-coe-202504-openrc.sh
-source .venv/bin/activate
+# Load your OpenStack credentials
+source /path/to/your-openrc.sh
+
+# Activate the environment where openstack/kubectl/helm are available
+# (conda env, virtualenv, module environment, etc.)
+# Example:
+# source /path/to/your/env/bin/activate
+
 export K8S_CLUSTER_NAME=k8s
 bash kubernetes_magnum/configure_kubectl_locally.sh
 export KUBECONFIG=$(pwd)/config

--- a/posts/2026-03-04-custom-jupyterhub-repo2docker-image.md
+++ b/posts/2026-03-04-custom-jupyterhub-repo2docker-image.md
@@ -7,36 +7,37 @@ layout: post
 title: Auto-build JupyterHub images with repo2docker and GitHub Actions
 ---
 
-Overview: Instead of maintaining a `Dockerfile`, you can build a JupyterHub-ready single-user image from repository configuration files (`environment.yml`, optional `postBuild`) using `repo2docker`. This keeps customization simple while still producing reproducible images for Zero to JupyterHub (Z2JH).
+Build and publish a JupyterHub-ready image directly from GitHub using `repo2docker`.
 
-Template repository: <https://github.com/zonca/custom-jupyterhub-repo2docker-image>
+Template repository: <https://github.com/zonca/custom-jupyterhub-repo2docker-image>  
+Latest integration run: <https://github.com/zonca/custom-jupyterhub-repo2docker-image/actions/runs/22652277154>
 
-Working CI example run: <https://github.com/zonca/custom-jupyterhub-repo2docker-image/actions/runs/22650073814>
+Quick start:
 
-How it works:
+1. Create your own repository from the template.
+2. Edit `environment.yml` with your packages.
+3. Push to `main`.
+4. Let GitHub Actions build and publish your image to GHCR.
 
-1. Edit `environment.yml` to add packages.
-2. Push to GitHub.
-3. GitHub Actions builds the image with `repo2docker`, runs JupyterHub smoke tests, and publishes to GHCR on `main`.
-4. The workflow signs images with Cosign, generates an SBOM, and attests build provenance.
+The workflow also signs images with Cosign, produces an SBOM, and adds build provenance.
 
-Suggested image tags:
-
-- `latest` for quick testing
-- `YYYY-MM-DD-<shortsha>` for reproducible JupyterHub deployments
-
-How to use in Z2JH (`config.yaml`):
+Use in Z2JH (`config.yaml`):
 
 ```yaml
 singleuser:
   image:
     name: ghcr.io/zonca/custom-jupyterhub-repo2docker-image
-    tag: 2026-03-04-c588129
+    tag: 2026-03-04-320a95e
   cmd: jupyterhub-singleuser
   defaultUrl: /lab
 ```
 
-Then deploy:
+Why set `cmd: jupyterhub-singleuser` explicitly:
+
+- It guarantees the pod starts the JupyterHub-aware server process.
+- It avoids image/entrypoint defaults that can leave pods running but not usable from Hub.
+
+Deploy:
 
 ```bash
 helm upgrade --install jhub jupyterhub/jupyterhub \
@@ -45,9 +46,12 @@ helm upgrade --install jhub jupyterhub/jupyterhub \
   --values config.yaml
 ```
 
-Why this is useful:
+Tagging strategy:
 
-- Lower maintenance than Dockerfiles for common scientific stacks
-- Fast iteration by editing only `environment.yml`
-- Security and provenance integrated into CI by default
-- Clear path from template repository to production JupyterHub image
+- `latest` for quick validation
+- `YYYY-MM-DD-<shortsha>` for reproducible production deploys
+
+CI flow:
+
+1. `image.yml`: build, test, push, sign, and attest.
+2. `z2jh-integration.yml`: run a real Hub test on Kind after a successful image workflow.

--- a/posts/2026-03-04-custom-jupyterhub-repo2docker-image.md
+++ b/posts/2026-03-04-custom-jupyterhub-repo2docker-image.md
@@ -9,8 +9,9 @@ title: Auto-build JupyterHub images with repo2docker and GitHub Actions
 
 Build and publish a JupyterHub-ready image directly from GitHub using `repo2docker`.
 
-Use this when you run a JupyterHub and need to update user environments often, for example for classes, workshops, or shared research platforms.
-Instead of hand-maintaining a full Dockerfile, you declare environment changes in repo2docker files and let CI build and validate the image automatically before you deploy it to Hub.
+The main goal is to update your JupyterHub software stack by editing `environment.yml` only.
+Use this when you run a JupyterHub and need frequent environment updates, for example for classes, workshops, or shared research platforms.
+Instead of hand-maintaining a full Dockerfile, you change the Conda environment file in Git and CI builds, validates, and publishes a new Hub-ready image tag.
 
 Template repository: <https://github.com/zonca/custom-jupyterhub-repo2docker-image>  
 Previous Dockerfile-based repository: <https://github.com/zonca/custom-jupyterhub-docker-image>  

--- a/posts/2026-03-04-custom-jupyterhub-repo2docker-image.md
+++ b/posts/2026-03-04-custom-jupyterhub-repo2docker-image.md
@@ -7,59 +7,76 @@ layout: post
 title: Auto-build JupyterHub images with repo2docker and GitHub Actions
 ---
 
-Build and publish a JupyterHub-ready image directly from GitHub using `repo2docker`.
+*This guide explains how to automatically build a custom, JupyterHub-ready Docker image directly from GitHub using `repo2docker`, without having to write a complicated Dockerfile from scratch.*
 
-The main goal is to update your JupyterHub software stack by editing `environment.yml` only.
-Use this when you run a JupyterHub and need frequent environment updates, for example for classes, workshops, or shared research platforms.
-Instead of hand-maintaining a full Dockerfile, you change the Conda environment file in Git and CI builds, validates, and publishes a new Hub-ready image tag.
+### The Problem
 
-Template repository: <https://github.com/zonca/custom-jupyterhub-repo2docker-image>  
-Previous Dockerfile-based repository: <https://github.com/zonca/custom-jupyterhub-docker-image>  
-Latest integration run: <https://github.com/zonca/custom-jupyterhub-repo2docker-image/actions/runs/22652277154>
+If you run a JupyterHub—whether it's for a university class, a workshop, or a shared research platform—your users will need specific Python packages installed. 
 
-How this differs from the Dockerfile approach:
+Usually, customizing this software stack means writing a full `Dockerfile` by hand. Writing Dockerfiles can be complex, and maintaining them over time as packages change requires specialized knowledge of Docker commands and Linux server administration.
 
-- With the Dockerfile repo, most customization happens in `Dockerfile` layers.
-- With this repo2docker template, most customization happens in `environment.yml` (and optional `postBuild`).
-- Dockerfiles give maximum low-level control; repo2docker reduces maintenance for standard scientific Python environments.
-- This template also adds a separate Z2JH integration workflow that runs after image build to validate real JupyterHub startup.
+### The Solution: repo2docker
 
-repo2docker files used in this workflow:
+Instead of writing a `Dockerfile` from scratch, we can use a tool created by the Jupyter project called [repo2docker](https://repo2docker.readthedocs.io/). 
 
-- `environment.yml`: Conda environment definition (packages/channels).
-- `requirements.txt`: Optional pip packages.
-- `apt.txt`: Optional Ubuntu packages installed with `apt`.
-- `postBuild`: Optional build-time shell script (compile assets, install extras).
-- `start`: Optional runtime startup script.
+The goal of `repo2docker` is simple: it looks at standard configuration files (like `environment.yml` for Conda, or `requirements.txt` for pip) and automatically turns them into a fully functional Docker image. 
 
-In short: edit these files in Git, push, and CI produces a JupyterHub-usable image tag for your Helm config.
+With this approach, **you only need to update your list of packages in GitHub, and "Continuous Integration" (CI) pipelines will automatically build, test, and publish a new image ready for your JupyterHub.**
 
-Quick start:
+### Using the Template Repository
 
-1. Create your own repository from the template.
-2. Edit `environment.yml` with your packages.
-3. Push to `main`.
-4. Let GitHub Actions build and publish your image to GHCR.
+To make this as easy as possible, I have created a template repository that has everything set up for you:
 
-The workflow also signs images with Cosign, produces an SBOM, and adds build provenance.
+*   **Template repository:** <https://github.com/zonca/custom-jupyterhub-repo2docker-image>  
+*   **Previous Dockerfile-based repository:** <https://github.com/zonca/custom-jupyterhub-docker-image> *(for comparison)*
+*   **Latest integration run:** <https://github.com/zonca/custom-jupyterhub-repo2docker-image/actions/runs/22652277154>
 
-Use in Z2JH (`config.yaml`):
+#### How this differs from the traditional Dockerfile approach
+
+*   **Dockerfile approach:** You have maximum control over the environment, but you spend your time managing lower-level server details inside Docker layers.
+*   **repo2docker approach:** You spend your time specifying scientific packages in an `environment.yml` file. It drastically reduces maintenance, especially for standard scientific Python environments.
+
+#### The configuration files
+
+When using this template, you'll mainly interact with these simple files:
+
+*   `environment.yml`: The main Conda environment definition (for your Python packages and channels).
+*   `requirements.txt`: Optional pip packages.
+*   `apt.txt`: Optional Ubuntu system packages installed with `apt`.
+*   `postBuild`: An optional shell script for anything that needs to be compiled or run after packages are installed.
+*   `start`: An optional script that runs when the server starts up.
+
+### Quick Start Guide
+
+Here is all you need to do to get your custom JupyterHub image building:
+
+1.  **Create your repository:** Go to the [template repository](https://github.com/zonca/custom-jupyterhub-repo2docker-image) and click the "Use this template" button to create your own copy on GitHub.
+2.  **Add your packages:** Edit the `environment.yml` file in your new repository to include the software your users need.
+3.  **Save your changes:** Commit and push these changes to the `main` branch.
+4.  **Automatic Build:** GitHub Actions will automatically detect the changes, build the image, and publish it securely to the GitHub Container Registry (GHCR). 
+
+*Security bonus: The automated workflow also digitally signs the images with Cosign and produces security artifacts (SBOMs) to ensure your supply chain is secure.*
+
+### Deploying Your Image to JupyterHub
+
+Once GitHub Actions successfully builds your image, you can tell your JupyterHub (which typically runs on Kubernetes using Zero to JupyterHub / Z2JH) to start using it. 
+
+You configure this in your JupyterHub `config.yaml` file:
 
 ```yaml
 singleuser:
   image:
-    name: ghcr.io/zonca/custom-jupyterhub-repo2docker-image
+    name: ghcr.io/YOUR_GITHUB_USERNAME/custom-jupyterhub-repo2docker-image
     tag: 2026-03-04-320a95e
   cmd: jupyterhub-singleuser
   defaultUrl: /lab
 ```
 
-Why set `cmd: jupyterhub-singleuser` explicitly:
+*Note on Tags:* GitHub automatically creates unique tags based on the date and a short commit code (e.g., `2026-03-04-320a95e`). This guarantees you are running the exact version you just built. Avoid using the `latest` tag in production environments!
 
-- It guarantees the pod starts the JupyterHub-aware server process.
-- It avoids image/entrypoint defaults that can leave pods running but not usable from Hub.
+*Note on the `cmd` setting:* We explicitly set `cmd: jupyterhub-singleuser`. This guarantees the pod correctly starts the JupyterHub-aware server process and prevents any default settings from leaving the pod running but unusable from the Hub.
 
-Deploy:
+Finally, deploy the updated configuration using Helm:
 
 ```bash
 helm upgrade --install jhub jupyterhub/jupyterhub \
@@ -68,12 +85,8 @@ helm upgrade --install jhub jupyterhub/jupyterhub \
   --values config.yaml
 ```
 
-Tagging strategy:
+### Advanced Automated Testing
 
-- `latest` for quick validation
-- `YYYY-MM-DD-<shortsha>` for reproducible production deploys
+To make sure you never accidentally publish a broken image, the template includes a real-world integration test. 
 
-CI flow:
-
-1. `image.yml`: build, test, push, sign, and attest.
-2. `z2jh-integration.yml`: run a real Hub test on Kind after a successful image workflow.
+After your new image is built, a separate GitHub workflow (`z2jh-integration.yml`) spins up a miniature Kubernetes cluster using `kind`, installs JupyterHub, and actually makes sure a real Hub can start up using your successfully built image workflow!

--- a/posts/2026-03-04-custom-jupyterhub-repo2docker-image.md
+++ b/posts/2026-03-04-custom-jupyterhub-repo2docker-image.md
@@ -9,8 +9,19 @@ title: Auto-build JupyterHub images with repo2docker and GitHub Actions
 
 Build and publish a JupyterHub-ready image directly from GitHub using `repo2docker`.
 
+This post shows a lightweight path from package configuration files to a production-ready JupyterHub image.
+The goal is to keep customization simple while still getting reproducible builds, security metadata, and an end-to-end integration test that verifies the image actually works in Hub.
+
 Template repository: <https://github.com/zonca/custom-jupyterhub-repo2docker-image>  
+Previous Dockerfile-based repository: <https://github.com/zonca/custom-jupyterhub-docker-image>  
 Latest integration run: <https://github.com/zonca/custom-jupyterhub-repo2docker-image/actions/runs/22652277154>
+
+How this differs from the Dockerfile approach:
+
+- With the Dockerfile repo, most customization happens in `Dockerfile` layers.
+- With this repo2docker template, most customization happens in `environment.yml` (and optional `postBuild`).
+- Dockerfiles give maximum low-level control; repo2docker reduces maintenance for standard scientific Python environments.
+- This template also adds a separate Z2JH integration workflow that runs after image build to validate real JupyterHub startup.
 
 Quick start:
 

--- a/posts/2026-03-04-custom-jupyterhub-repo2docker-image.md
+++ b/posts/2026-03-04-custom-jupyterhub-repo2docker-image.md
@@ -1,0 +1,53 @@
+---
+categories:
+- jupyterhub
+- python
+date: '2026-03-04'
+layout: post
+title: Auto-build JupyterHub images with repo2docker and GitHub Actions
+---
+
+Overview: Instead of maintaining a `Dockerfile`, you can build a JupyterHub-ready single-user image from repository configuration files (`environment.yml`, optional `postBuild`) using `repo2docker`. This keeps customization simple while still producing reproducible images for Zero to JupyterHub (Z2JH).
+
+Template repository: <https://github.com/zonca/custom-jupyterhub-repo2docker-image>
+
+Working CI example run: <https://github.com/zonca/custom-jupyterhub-repo2docker-image/actions/runs/22650073814>
+
+How it works:
+
+1. Edit `environment.yml` to add packages.
+2. Push to GitHub.
+3. GitHub Actions builds the image with `repo2docker`, runs JupyterHub smoke tests, and publishes to GHCR on `main`.
+4. The workflow signs images with Cosign, generates an SBOM, and attests build provenance.
+
+Suggested image tags:
+
+- `latest` for quick testing
+- `YYYY-MM-DD-<shortsha>` for reproducible JupyterHub deployments
+
+How to use in Z2JH (`config.yaml`):
+
+```yaml
+singleuser:
+  image:
+    name: ghcr.io/zonca/custom-jupyterhub-repo2docker-image
+    tag: 2026-03-04-c588129
+  cmd: jupyterhub-singleuser
+  defaultUrl: /lab
+```
+
+Then deploy:
+
+```bash
+helm upgrade --install jhub jupyterhub/jupyterhub \
+  --namespace jhub \
+  --create-namespace \
+  --values config.yaml
+```
+
+Why this is useful:
+
+- Lower maintenance than Dockerfiles for common scientific stacks
+- Fast iteration by editing only `environment.yml`
+- Security and provenance integrated into CI by default
+- Clear path from template repository to production JupyterHub image

--- a/posts/2026-03-04-custom-jupyterhub-repo2docker-image.md
+++ b/posts/2026-03-04-custom-jupyterhub-repo2docker-image.md
@@ -9,8 +9,8 @@ title: Auto-build JupyterHub images with repo2docker and GitHub Actions
 
 Build and publish a JupyterHub-ready image directly from GitHub using `repo2docker`.
 
-This post shows a lightweight path from package configuration files to a production-ready JupyterHub image.
-The goal is to keep customization simple while still getting reproducible builds, security metadata, and an end-to-end integration test that verifies the image actually works in Hub.
+Use this when you run a JupyterHub and need to update user environments often, for example for classes, workshops, or shared research platforms.
+Instead of hand-maintaining a full Dockerfile, you declare environment changes in repo2docker files and let CI build and validate the image automatically before you deploy it to Hub.
 
 Template repository: <https://github.com/zonca/custom-jupyterhub-repo2docker-image>  
 Previous Dockerfile-based repository: <https://github.com/zonca/custom-jupyterhub-docker-image>  
@@ -22,6 +22,16 @@ How this differs from the Dockerfile approach:
 - With this repo2docker template, most customization happens in `environment.yml` (and optional `postBuild`).
 - Dockerfiles give maximum low-level control; repo2docker reduces maintenance for standard scientific Python environments.
 - This template also adds a separate Z2JH integration workflow that runs after image build to validate real JupyterHub startup.
+
+repo2docker files used in this workflow:
+
+- `environment.yml`: Conda environment definition (packages/channels).
+- `requirements.txt`: Optional pip packages.
+- `apt.txt`: Optional Ubuntu packages installed with `apt`.
+- `postBuild`: Optional build-time shell script (compile assets, install extras).
+- `start`: Optional runtime startup script.
+
+In short: edit these files in Git, push, and CI produces a JupyterHub-usable image tag for your Helm config.
 
 Quick start:
 


### PR DESCRIPTION
This PR significantly rewrites the `2026-03-04-custom-jupyterhub-repo2docker-image.md` blog post to be much more beginner-friendly.

Changes:
- Reorganized the structure into "The Problem", "The Solution", "Using the Template Repository", etc.
- Added simple explanations of what `repo2docker` is and why it's easier than writing Dockerfiles manually.
- Clarified what the configuration files (e.g., `environment.yml`) do.
- Provided a clear "Quick Start Guide" with numbered steps.
- Kept the advanced topics (like Z2JH deployment and Helm commands) but explained *why* they are needed (e.g., why `cmd: jupyterhub-singleuser` is explicit).

This fulfills the objective to review the post, understand the underlying repository architecture, and explain the rationale in simple form for users who might be new to JupyterHub Docker integrations.
