### PR TITLE
Add missing date to latest post

### DIFF
--- a/posts/2026-03-06-how-to-pronounce-andrea-in-italian.md
+++ b/posts/2026-03-06-how-to-pronounce-andrea-in-italian.md
@@ -1,5 +1,6 @@
 ---
 title: "How to pronounce Andrea in Italian"
+date: '2026-03-06'
 ---
 
 The Italian pronunciation of Andrea is:


### PR DESCRIPTION
Added the missing `date` field to the YAML frontmatter of `posts/2026-03-06-how-to-pronounce-andrea-in-italian.md` so that the post correctly appears on the homepage with its date. Verified the fix by running `make render`.

---
*PR created automatically by Jules for task [13957888156512752643](https://jules.google.com/task/13957888156512752643) started by @zonca*