### PR TITLE
Add post explaining how to use UCSD SMTP with GMAIL addresses

### DIFF
--- a/posts/2025-09-23-inspect-smtp-sending-through-ucsd.md
+++ b/posts/2025-09-23-inspect-smtp-sending-through-ucsd.md
@@ -5,6 +5,8 @@ date: "2025-09-23"
 categories: [Python]
 ---
 
+* **UPDATED 2026-04-13**: This post is obsolete, please refer to the new post [Send email using UCSD SMTP with a GMAIL-based address](./2026-04-13-send-email-ucsd-gmail.md).
+
 When configuring email sending through UCSD, it can be surprisingly unclear which SMTP server to use. The official documentation mentions three options: `smtp.ucsd.edu`, `smtp.gmail.com`, and `smtp.office365.com`. This ambiguity often leads to trial-and-error, making it difficult to set up applications or scripts that reliably send emails. To cut through the confusion, I developed a simple script to systematically test connectivity and sending capabilities for all three servers.
 
 This script, available on GitHub at [https://github.com/zonca/test_smtp_ucsd](https://github.com/zonca/test_smtp_ucsd), helps identify the most suitable SMTP server for your specific needs within the UCSD environment. It provides a clear way to determine which server offers the best reliability and performance, saving you the hassle of manual testing and configuration guesswork.

--- a/posts/2026-04-13-send-email-ucsd-gmail.md
+++ b/posts/2026-04-13-send-email-ucsd-gmail.md
@@ -1,0 +1,18 @@
+---
+title: "Send email using UCSD SMTP with a GMAIL-based address"
+date: "2026-04-13"
+categories:
+- Python
+---
+
+If you have a GMAIL-based UCSD email address and need to send email programmatically or via an email client using SMTP, you can use Google's SMTP servers.
+
+First, you need to generate an App Password:
+Go to [https://myaccount.google.com/apppasswords](https://myaccount.google.com/apppasswords) to get an app password.
+
+Then, configure your application or email client with the following settings:
+
+*   **Username:** `username@ucsd.edu`
+*   **Password:** your newly generated app password
+*   **SMTP Server:** `smtp.gmail.com`
+*   **Port:** `465` (for SSL)


### PR DESCRIPTION
- Created a new blog post explaining how to send email using UCSD SMTP for GMAIL-based addresses, including getting an app password and configuring SMTP servers.
- Updated an older blog post (`2025-09-23-inspect-smtp-sending-through-ucsd.md`) to mark it as obsolete and link to the new post using the relative markdown path.

---
*PR created automatically by Jules for task [16304188539253984481](https://jules.google.com/task/16304188539253984481) started by @zonca*