### PR TITLE
Add section on updating Confluence pages from Markdown

### DIFF
--- a/posts/2026-03-11-export-confluence-markdown-cli.md
+++ b/posts/2026-03-11-export-confluence-markdown-cli.md
@@ -30,3 +30,18 @@ confluence export 123456789 --dest ./exports
 ```
 
 Replace `123456789` with the ID of your Confluence page. You can find the Page ID in the URL when editing the page, or by using `Page Information` from the Confluence menu.
+
+### Updating pages from Markdown
+
+You can also push Markdown files back to Confluence:
+
+```bash
+confluence update <PAGE_ID> -f page.md --format markdown
+```
+
+Note: use `--format markdown` (not `storage` or `html`, those will break the formatting). Also, the CLI does not convert `[text](url)` markdown links. Put URLs on their own line instead:
+
+```markdown
+See the project at:
+`https://github.com/user/repo`
+```


### PR DESCRIPTION
Add a new section with instructions on how to push Markdown files back to Confluence using the CLI.

Includes tips:
- Use `--format markdown` to preserve formatting
- URL workaround: put URLs on their own line with backticks