### PR TITLE
feat: Add OpenStack Magnum JupyterHub tutorial

### DIFF
--- a/posts/2026-04-22-deploy-jupyterhub-openstack-magnum-tofu.md
+++ b/posts/2026-04-22-deploy-jupyterhub-openstack-magnum-tofu.md
@@ -1,0 +1,104 @@
+---
+categories:
+- kubernetes
+- openstack
+- jupyterhub
+date: '2026-04-22'
+layout: post
+title: "Deploying JupyterHub on OpenStack Magnum with OpenTofu"
+---
+
+In this tutorial, we will walk through the process of deploying a production-ready JupyterHub on OpenStack Magnum using **OpenTofu**. This approach provides a modular, declarative, and reproducible way to manage your Kubernetes infrastructure and the applications running on it.
+
+## Prerequisites
+
+- Access to an OpenStack cloud (e.g., Jetstream2)
+- OpenTofu installed locally
+- OpenStack credentials sourced in your environment
+
+## The Modular Architecture
+
+We use a shared OpenTofu module to manage the core Magnum cluster logic. This allows us to easily switch between a basic Kubernetes deployment and a full JupyterHub stack.
+
+### 1. Creating a Basic Kubernetes Cluster
+
+First, we define a simple cluster using our shared module. OpenTofu allows us to specify the desired state, such as node counts and flavors.
+
+```hcl
+module "kubernetes_cluster" {
+  source = "./modules/cluster"
+
+  cluster_name = "k8s-tofu-only"
+  node_count   = 2
+  flavor       = "m3.small"
+}
+```
+
+When we run `tofu apply`, OpenTofu communicates with the Magnum API to provision the VMs and set up the Kubernetes control plane.
+
+**Sample Output:**
+```text
+module.kubernetes_cluster.openstack_containerinfra_cluster_v1.cluster: Creating...
+module.kubernetes_cluster.openstack_containerinfra_cluster_v1.cluster: Still creating... [1m0s elapsed]
+...
+module.kubernetes_cluster.openstack_containerinfra_cluster_v1.cluster: Creation complete after 9m33s [id=CLUSTER_UUID]
+module.kubernetes_cluster.local_file.kubeconfig: Creating...
+module.kubernetes_cluster.local_file.kubeconfig: Creation complete after 0s [id=CONFIG_SHA]
+
+Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
+```
+
+### 2. Deploying the Full JupyterHub Stack
+
+For a full deployment, we extend the configuration to include networking (Floating IPs), DNS, and the necessary Helm charts.
+
+```hcl
+module "kubernetes_cluster" {
+  source = "../modules/cluster"
+  cluster_name = "k8s-tofu-jhub"
+}
+
+# ... Additional resources for Floating IP, DNS, Ingress, and JupyterHub
+```
+
+The process automatically handles the installation of:
+- **Ingress-Nginx**: For load balancing and external access.
+- **Cert-Manager**: For automated HTTPS certificates via Let's Encrypt.
+- **JupyterHub**: Using the official Helm chart.
+
+**Helm Installation Output:**
+```text
+null_resource.install_ingress (local-exec): Release "ingress-nginx" does not exist. Installing it now.
+null_resource.install_ingress: Creation complete after 32s [id=INGRESS_ID]
+
+null_resource.install_jupyterhub (local-exec): Release "jhub" does not exist. Installing it now.
+null_resource.install_jupyterhub: Creation complete after 1m24s [id=JHUB_ID]
+
+Apply complete! Resources: 14 added, 0 changed, 0 destroyed.
+
+Outputs:
+jupyterhub_url = "https://jhub-test.example.projects.jetstream-cloud.org"
+```
+
+## Verification
+
+Once the deployment is complete, you can verify the status of your JupyterHub pods:
+
+```bash
+export KUBECONFIG=./config
+kubectl get pods -n jhub
+```
+
+**Output:**
+```text
+NAME                              READY   STATUS    RESTARTS   AGE
+cm-acme-http-solver-pbwzf         1/1     Running   0          85s
+hub-5545f479f9-fjqcd              1/1     Running   0          85s
+proxy-5766564b84-hbtwr            1/1     Running   0          85s
+```
+
+## Conclusion
+
+Using OpenTofu to manage JupyterHub on OpenStack Magnum provides a clean separation between infrastructure and application logic. This modular setup is easy to maintain, scale, and reproduce across different projects.
+
+For the full source code and refactored Tofu recipes, visit the [jupyterhub-deploy-kubernetes-jetstream](https://github.com/zonca/jupyterhub-deploy-kubernetes-jetstream) repository.

--- a/posts/2026-04-22-deploy-jupyterhub-openstack-magnum-tofu.md
+++ b/posts/2026-04-22-deploy-jupyterhub-openstack-magnum-tofu.md
@@ -11,18 +11,21 @@ title: "Deploying JupyterHub on OpenStack Magnum with OpenTofu"
 In this tutorial, we will walk through the process of deploying a production-ready JupyterHub on OpenStack Magnum using **OpenTofu**. 
 
 ### What you get at the end
+
 By following this guide, you will have:
-- A fully functional **Kubernetes cluster** provisioned via OpenStack Magnum.
-- A **public Floating IP** automatically bound to an Nginx Ingress Controller.
-- Automatic **HTTPS certificates** provided by Let's Encrypt and Cert-Manager.
-- A customized **JupyterHub** installation accessible via a professional subdomain (e.g., `jhub-test.cis230085.projects.jetstream-cloud.org`).
-- A **modular OpenTofu configuration** that is easy to maintain and reproduce.
+
+* A fully functional **Kubernetes cluster** provisioned via OpenStack Magnum.
+* A **public Floating IP** automatically bound to an Nginx Ingress Controller.
+* Automatic **HTTPS certificates** provided by Let's Encrypt and Cert-Manager.
+* A customized **JupyterHub** installation accessible via a professional subdomain (e.g., `jhub-test.cis230085.projects.jetstream-cloud.org`).
+* A **modular OpenTofu configuration** that is easy to maintain and reproduce.
 
 ---
 
 ## 1. Prerequisites
 
 ### Install OpenTofu
+
 If you don't have OpenTofu installed, you can install it using the official script:
 
 ```bash
@@ -32,6 +35,7 @@ curl --proto '=https' --tlsv1.2 -fsSL https://get.opentofu.org/install.sh | sh
 Alternatively, on Linux with snap: `snap install opentofu --classic`.
 
 ### Clone the Material
+
 All the OpenTofu recipes and configuration templates are available in the following repository:
 
 ```bash
@@ -40,7 +44,9 @@ cd jupyterhub-deploy-kubernetes-jetstream/tofu_magnum
 ```
 
 ### Get OpenStack Credentials
+
 You need an "Application Credential" to allow OpenTofu to manage resources on your behalf:
+
 1. Log in to your OpenStack Dashboard (e.g., Jetstream2 Horizon).
 2. Navigate to **Identity** -> **Application Credentials**.
 3. Create a new credential and download the **OpenStack RC** file.
@@ -57,6 +63,7 @@ You need an "Application Credential" to allow OpenTofu to manage resources on yo
 All the details of your cluster—such as name, number of nodes, machine sizes (flavors), and your JupyterHub subdomain—are controlled via a single file: `terraform.tfvars`.
 
 ### Edit your settings
+
 Navigate to the deployment directory and create/edit your `terraform.tfvars`:
 
 ```bash
@@ -65,17 +72,19 @@ cp terraform.tfvars.example terraform.tfvars
 ```
 
 **Key variables to customize:**
-- `cluster_name`: The name of your Magnum cluster.
-- `node_count`: Initial number of worker nodes.
-- `worker_flavor`: The machine type (e.g., `m3.small`).
-- `subdomain`: The prefix for your URL (e.g., `my-hub`).
-- `letsencrypt_email`: Your email for HTTPS certificate notifications.
+
+* `cluster_name`: The name of your Magnum cluster.
+* `node_count`: Initial number of worker nodes.
+* `worker_flavor`: The machine type (e.g., `m3.small`).
+* `subdomain`: The prefix for your URL (e.g., `my-hub`).
+* `letsencrypt_email`: Your email for HTTPS certificate notifications.
 
 ---
 
 ## 3. Deployment
 
 ### Initialize and Apply
+
 First, initialize the OpenTofu workspace to download the necessary providers and modules:
 
 ```bash
@@ -91,6 +100,7 @@ tofu apply
 OpenTofu will first provision the Kubernetes VMs via Magnum, then automatically set up the networking, DNS, and finally install the Helm charts for Ingress and JupyterHub.
 
 **Sample Cluster Creation Output:**
+
 ```text
 module.kubernetes_cluster.openstack_containerinfra_cluster_v1.cluster: Creating...
 module.kubernetes_cluster.openstack_containerinfra_cluster_v1.cluster: Still creating... [1m0s elapsed]
@@ -99,6 +109,7 @@ module.kubernetes_cluster.openstack_containerinfra_cluster_v1.cluster: Creation 
 ```
 
 **Sample Helm Installation Output:**
+
 ```text
 null_resource.install_jupyterhub (local-exec): Release "jhub" does not exist. Installing it now.
 null_resource.install_jupyterhub: Creation complete after 1m24s
@@ -121,6 +132,7 @@ kubectl get pods -n jhub
 ```
 
 **Expected Result:**
+
 ```text
 NAME                              READY   STATUS    RESTARTS   AGE
 cm-acme-http-solver-pbwzf         1/1     Running   0          85s

--- a/posts/2026-04-22-deploy-jupyterhub-openstack-magnum-tofu.md
+++ b/posts/2026-04-22-deploy-jupyterhub-openstack-magnum-tofu.md
@@ -8,88 +8,119 @@ layout: post
 title: "Deploying JupyterHub on OpenStack Magnum with OpenTofu"
 ---
 
-In this tutorial, we will walk through the process of deploying a production-ready JupyterHub on OpenStack Magnum using **OpenTofu**. This approach provides a modular, declarative, and reproducible way to manage your Kubernetes infrastructure and the applications running on it.
+In this tutorial, we will walk through the process of deploying a production-ready JupyterHub on OpenStack Magnum using **OpenTofu**. 
 
-## Prerequisites
+### What you get at the end
+By following this guide, you will have:
+- A fully functional **Kubernetes cluster** provisioned via OpenStack Magnum.
+- A **public Floating IP** automatically bound to an Nginx Ingress Controller.
+- Automatic **HTTPS certificates** provided by Let's Encrypt and Cert-Manager.
+- A customized **JupyterHub** installation accessible via a professional subdomain (e.g., `jhub-test.cis230085.projects.jetstream-cloud.org`).
+- A **modular OpenTofu configuration** that is easy to maintain and reproduce.
 
-- Access to an OpenStack cloud (e.g., Jetstream2)
-- OpenTofu installed locally
-- OpenStack credentials sourced in your environment
+---
 
-## The Modular Architecture
+## 1. Prerequisites
 
-We use a shared OpenTofu module to manage the core Magnum cluster logic. This allows us to easily switch between a basic Kubernetes deployment and a full JupyterHub stack.
+### Install OpenTofu
+If you don't have OpenTofu installed, you can install it using the official script:
 
-### 1. Creating a Basic Kubernetes Cluster
-
-First, we define a simple cluster using our shared module. OpenTofu allows us to specify the desired state, such as node counts and flavors.
-
-```hcl
-module "kubernetes_cluster" {
-  source = "./modules/cluster"
-
-  cluster_name = "k8s-tofu-only"
-  node_count   = 2
-  flavor       = "m3.small"
-}
+```bash
+curl --proto '=https' --tlsv1.2 -fsSL https://get.opentofu.org/install.sh | sh
 ```
 
-When we run `tofu apply`, OpenTofu communicates with the Magnum API to provision the VMs and set up the Kubernetes control plane.
+Alternatively, on Linux with snap: `snap install opentofu --classic`.
 
-**Sample Output:**
+### Clone the Material
+All the OpenTofu recipes and configuration templates are available in the following repository:
+
+```bash
+git clone https://github.com/zonca/jupyterhub-deploy-kubernetes-jetstream
+cd jupyterhub-deploy-kubernetes-jetstream/tofu_magnum
+```
+
+### Get OpenStack Credentials
+You need an "Application Credential" to allow OpenTofu to manage resources on your behalf:
+1. Log in to your OpenStack Dashboard (e.g., Jetstream2 Horizon).
+2. Navigate to **Identity** -> **Application Credentials**.
+3. Create a new credential and download the **OpenStack RC** file.
+4. Save it as `app-cred-openrc.sh` in the root of the cloned repository.
+5. Source it in your terminal:
+   ```bash
+   source app-cred-openrc.sh
+   ```
+
+---
+
+## 2. Configuration
+
+All the details of your cluster—such as name, number of nodes, machine sizes (flavors), and your JupyterHub subdomain—are controlled via a single file: `terraform.tfvars`.
+
+### Edit your settings
+Navigate to the deployment directory and create/edit your `terraform.tfvars`:
+
+```bash
+cd full_stack_https
+cp terraform.tfvars.example terraform.tfvars
+```
+
+**Key variables to customize:**
+- `cluster_name`: The name of your Magnum cluster.
+- `node_count`: Initial number of worker nodes.
+- `worker_flavor`: The machine type (e.g., `m3.small`).
+- `subdomain`: The prefix for your URL (e.g., `my-hub`).
+- `letsencrypt_email`: Your email for HTTPS certificate notifications.
+
+---
+
+## 3. Deployment
+
+### Initialize and Apply
+First, initialize the OpenTofu workspace to download the necessary providers and modules:
+
+```bash
+tofu init
+```
+
+Then, deploy the entire stack:
+
+```bash
+tofu apply
+```
+
+OpenTofu will first provision the Kubernetes VMs via Magnum, then automatically set up the networking, DNS, and finally install the Helm charts for Ingress and JupyterHub.
+
+**Sample Cluster Creation Output:**
 ```text
 module.kubernetes_cluster.openstack_containerinfra_cluster_v1.cluster: Creating...
 module.kubernetes_cluster.openstack_containerinfra_cluster_v1.cluster: Still creating... [1m0s elapsed]
 ...
-module.kubernetes_cluster.openstack_containerinfra_cluster_v1.cluster: Creation complete after 9m33s [id=CLUSTER_UUID]
-module.kubernetes_cluster.local_file.kubeconfig: Creating...
-module.kubernetes_cluster.local_file.kubeconfig: Creation complete after 0s [id=CONFIG_SHA]
-
-Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
+module.kubernetes_cluster.openstack_containerinfra_cluster_v1.cluster: Creation complete after 9m30s
 ```
 
-### 2. Deploying the Full JupyterHub Stack
-
-For a full deployment, we extend the configuration to include networking (Floating IPs), DNS, and the necessary Helm charts.
-
-```hcl
-module "kubernetes_cluster" {
-  source = "../modules/cluster"
-  cluster_name = "k8s-tofu-jhub"
-}
-
-# ... Additional resources for Floating IP, DNS, Ingress, and JupyterHub
-```
-
-The process automatically handles the installation of:
-- **Ingress-Nginx**: For load balancing and external access.
-- **Cert-Manager**: For automated HTTPS certificates via Let's Encrypt.
-- **JupyterHub**: Using the official Helm chart.
-
-**Helm Installation Output:**
+**Sample Helm Installation Output:**
 ```text
-null_resource.install_ingress (local-exec): Release "ingress-nginx" does not exist. Installing it now.
-null_resource.install_ingress: Creation complete after 32s [id=INGRESS_ID]
-
 null_resource.install_jupyterhub (local-exec): Release "jhub" does not exist. Installing it now.
-null_resource.install_jupyterhub: Creation complete after 1m24s [id=JHUB_ID]
+null_resource.install_jupyterhub: Creation complete after 1m24s
 
 Apply complete! Resources: 14 added, 0 changed, 0 destroyed.
 
 Outputs:
-jupyterhub_url = "https://jhub-test.example.projects.jetstream-cloud.org"
+jupyterhub_url = "https://jhub-test.cis230085.projects.jetstream-cloud.org"
 ```
 
-## Verification
+---
 
-Once the deployment is complete, you can verify the status of your JupyterHub pods:
+## 4. Verification
+
+Once the command finishes, your JupyterHub should be live! You can verify the status of the internal pods using `kubectl`:
 
 ```bash
 export KUBECONFIG=./config
 kubectl get pods -n jhub
 ```
 
-**Output:**
+**Expected Result:**
 ```text
 NAME                              READY   STATUS    RESTARTS   AGE
 cm-acme-http-solver-pbwzf         1/1     Running   0          85s
@@ -99,6 +130,4 @@ proxy-5766564b84-hbtwr            1/1     Running   0          85s
 
 ## Conclusion
 
-Using OpenTofu to manage JupyterHub on OpenStack Magnum provides a clean separation between infrastructure and application logic. This modular setup is easy to maintain, scale, and reproduce across different projects.
-
-For the full source code and refactored Tofu recipes, visit the [jupyterhub-deploy-kubernetes-jetstream](https://github.com/zonca/jupyterhub-deploy-kubernetes-jetstream) repository.
+Using OpenTofu to manage JupyterHub on OpenStack Magnum provides a clean, automated way to handle both infrastructure and applications. By using the modular setup provided in this tutorial, you can easily scale your hub or replicate the deployment for different projects.


### PR DESCRIPTION
This PR adds a new tutorial post on deploying JupyterHub on OpenStack Magnum using OpenTofu. 

The tutorial covers:
- The benefits of a modular Tofu architecture.
- Creating a basic K8s cluster.
- Deploying a full stack with Ingress, Cert-Manager, and JupyterHub.
- Verification steps and sample anonymized outputs.

The recipes used in this tutorial correspond to the recent refactoring in the `jupyterhub-deploy-kubernetes-jetstream` repository.
