### PR TITLE
Add SDSC HPC and Data Science Summer Institute 2026 post

### DIFF
--- a/posts/2026-04-23-sdsc-summer-institute-2026.md
+++ b/posts/2026-04-23-sdsc-summer-institute-2026.md
@@ -1,0 +1,38 @@
+---
+title: "SDSC HPC and Data Science Summer Institute 2026"
+date: 2026-04-23
+categories:
+  - events
+  - HPC
+  - data-science
+  - education
+---
+
+The [SDSC HPC and Data Science Summer Institute 2026](https://www.sdsc.edu/events/202608-HPC-Data-Science-Summer-Institute.html) is a week-long, in-person training event focused on introductory-to-intermediate topics in High Performance Computing (HPC), Data Science, and Artificial Intelligence (AI).
+
+**When:** August 3–7, 2026 (in-person at UC San Diego)
+**Location:** San Diego Supercomputer Center, UC San Diego
+**Limited to 45 participants**
+
+## What You'll Learn
+
+The institute offers hands-on tutorials on the [Expanse supercomputer](https://www.sdsc.edu/hpc/expanse/index.html) covering:
+
+- **Parallel Computing** with MPI & OpenMP
+- **High Throughput Computing**
+- **Deep Learning** with GPUs
+- **GPU Computing and Programming**
+- **Python for HPC**
+- **Data Management** and transfers
+- **Performance Tuning**
+- **Scientific Computing Best Practices**
+
+## Who Should Apply
+
+Researchers and educators in academia and industry with basic UNIX/Linux and programming experience.
+
+## How to Register
+
+Register at [na.eventscloud.com](https://na.eventscloud.com/ereg/newreg.php?eventid=869582&).
+
+[View the full agenda on GitHub](https://github.com/sdsc/sdsc-summer-institute-2026/blob/main/AGENDA.md)


### PR DESCRIPTION
## Summary
- Add blog post about SDSC HPC and Data Science Summer Institute 2026 (August 3-7, in-person at UC San Diego)
- Includes topics covered, registration info, and link to full agenda on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)