### PR TITLE
Fix missing date in notebook

### DIFF
--- a/posts/2026-05-05-healpy-harmonic-ud-grade.ipynb
+++ b/posts/2026-05-05-healpy-harmonic-ud-grade.ipynb
@@ -1,6 +1,25 @@
 {
  "cells": [
   {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "aliases:\n",
+    "- /2026/05/healpy-harmonic-ud-grade\n",
+    "categories:\n",
+    "- python\n",
+    "- astrophysics\n",
+    "- healpy\n",
+    "date: '2026-05-05'\n",
+    "description: harmonic_ud_grade vs ud_grade A Focused Comparison.\n",
+    "output-file: 2026-05-05-healpy-harmonic-ud-grade.html\n",
+    "title: \"harmonic_ud_grade vs ud_grade: A Focused Comparison\"\n",
+    "\n",
+    "---\n"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "1902f216",
    "metadata": {},


### PR DESCRIPTION
Added a raw frontmatter cell to `posts/2026-05-05-healpy-harmonic-ud-grade.ipynb` to provide the `date` attribute (and other necessary metadata like title and categories), fixing an issue where this post was missing its date.

---
*PR created automatically by Jules for task [10949880667079570463](https://jules.google.com/task/10949880667079570463) started by @zonca*