### PR TITLE
Fix capitalization in blog post titles

### DIFF
--- a/posts/2013-08-30-interactive-figures-planck-power-spectra.md
+++ b/posts/2013-08-30-interactive-figures-planck-power-spectra.md
@@ -7,8 +7,7 @@ categories:
 date: 2013-08-30 08:52
 layout: post
 slug: interactive-figures-planck-power-spectra
-title: Interactive figures in the browser - CMB Power Spectra
-
+title: Interactive figures in the browser - CMB power spectra
 ---
 
 <p>

--- a/posts/2013-09-02-run-hadoop-python-jobs-on-amazon-with-mrjob.md
+++ b/posts/2013-09-02-run-hadoop-python-jobs-on-amazon-with-mrjob.md
@@ -7,8 +7,7 @@ categories:
 date: 2013-09-02 02:36
 layout: post
 slug: run-hadoop-python-jobs-on-amazon-with-mrjob
-title: Run Hadoop Python jobs on Amazon with MrJob
-
+title: Run Hadoop Python jobs on Amazon with mrjob
 ---
 
 <br/>

--- a/posts/2013-11-20-published-paper-destriping-CMB-polarimeter.md
+++ b/posts/2013-11-20-published-paper-destriping-CMB-polarimeter.md
@@ -7,8 +7,7 @@ categories:
 date: 2013-11-20 21:30
 layout: post
 slug: published-paper-destriping-CMB-polarimeter
-title: Published paper on Destriping Cosmic Microwave Background Polarimeter data
-
+title: Published paper on destriping Cosmic Microwave Background polarimeter data
 ---
 
 TL;DR version:

--- a/posts/2013-12-18-run-ipython-notebook-on-HPC-cluster-via-PBS.md
+++ b/posts/2013-12-18-run-ipython-notebook-on-HPC-cluster-via-PBS.md
@@ -7,8 +7,7 @@ categories:
 date: 2013-12-18 16:30
 layout: post
 slug: run-ipython-notebook-on-HPC-cluster-via-PBS
-title: Run IPython Notebook on a HPC Cluster via PBS
-
+title: Run IPython Notebook on a HPC cluster via PBS
 ---
 
 The [IPython notebook](http://ipython.org/notebook.html) is a great tool for data exploration

--- a/posts/2015-04-02-jupyterhub-hpc.md
+++ b/posts/2015-04-02-jupyterhub-hpc.md
@@ -8,8 +8,7 @@ categories:
 date: 2015-04-02 9:00
 layout: post
 slug: jupyterhub-hpc
-title: Run Jupyterhub on a Supercomputer
-
+title: Run Jupyterhub on a supercomputer
 ---
 
 > **Summary**: I developed a plugin for [Jupyterhub](https://github.com/jupyter/jupyterhub "jupyterhub"): [RemoteSpawner](https://github.com/zonca/remotespawner), it has a proof-of-concept interface with the Supercomputer Gordon at UC San Diego to spawn IPython Notebook instances as jobs throught the queue and tunnel the interface back to the Jupyterhub instance.

--- a/posts/2016-04-16-jupyterhub-sdsc-cloud.md
+++ b/posts/2016-04-16-jupyterhub-sdsc-cloud.md
@@ -7,8 +7,7 @@ categories:
 date: 2016-04-16 12:00
 layout: post
 slug: jupyterhub-sdsc-cloud
-title: Deploy Jupyterhub on a Virtual Machine for a Workshop
-
+title: Deploy Jupyterhub on a virtual machine for a workshop
 ---
 
 This tutorial describes the steps to install a Jupyterhub instance on a single machine suitable for hosting a workshop, suitable for having people login with training accounts on Jupyter Notebooks running Python 2/3, R, Julia with also Terminal access on Docker containers.

--- a/posts/2017-05-16-jupyterhub-batchspawner-ssh.md
+++ b/posts/2017-05-16-jupyterhub-batchspawner-ssh.md
@@ -8,8 +8,7 @@ categories:
 date: 2017-05-16 22:00
 layout: post
 slug: jupyterhub-hpc-batchspawner-ssh
-title: Deploy Jupyterhub on a Supercomputer with SSH Authentication
-
+title: Deploy Jupyterhub on a supercomputer with SSH authentication
 ---
 
 The best way to deploy Jupyterhub with an interface to a Supercomputer is through the use of `batchspawner`. I have a sample deployment explained in an older blog post: <https://zonca.github.io/2017/02/sample-deployment-jupyterhub-hpc.html>

--- a/posts/2017-08-11-jupyterhub-globus-comet-singularity.md
+++ b/posts/2017-08-11-jupyterhub-globus-comet-singularity.md
@@ -8,7 +8,7 @@ categories:
 date: 2017-08-11 18:00
 layout: post
 slug: jupyterhub-globus-comet-singularity
-title: Deployment of Jupyterhub with Globus Auth to spawn Notebook on Comet in Singularity
+title: Deployment of Jupyterhub with Globus Auth to spawn notebook on Comet in Singularity
   containers
 
 ---

--- a/posts/2018-07-23-pearc18_paper_deploy_jupyterhub_xsede.md
+++ b/posts/2018-07-23-pearc18_paper_deploy_jupyterhub_xsede.md
@@ -10,8 +10,7 @@ categories:
 date: 2018-07-23 12:00
 layout: post
 slug: pearc18-paper-deploy-jupyterhub-xsede
-title: PEARC18 Paper on Deploying Jupyterhub at scale on XSEDE
-
+title: PEARC18 paper on deploying Jupyterhub at scale on XSEDE
 ---
 
 Bob Sinkovits and I are presenting a paper at PEARC18 about:

--- a/posts/2018-10-26-pandas-astro-example.md
+++ b/posts/2018-10-26-pandas-astro-example.md
@@ -7,8 +7,7 @@ categories:
 date: 2018-10-26 18:00
 layout: post
 slug: pandas-astro-example
-title: Advanced pandas with Astrophysics example Notebook
-
+title: Advanced pandas with astrophysics example notebook
 ---
 
 Taught a lesson today on advanced `python` and `pandas` based on an example application in Astrophysics with simulations of data from the [Planck Satellite](https://en.wikipedia.org/wiki/Planck_(spacecraft)), features also a Binder button to run it yourself. Jupyter Notebook available at: <https://github.com/zonca/pandas-astro-example> under CC-BY

--- a/posts/2020-03-13-setup-https-kubernetes-letsencrypt.md
+++ b/posts/2020-03-13-setup-https-kubernetes-letsencrypt.md
@@ -7,8 +7,7 @@ categories:
 - jupyterhub
 date: '2020-03-13'
 layout: post
-title: Setup HTTPS on Kubernetes with Letsencrypt
-
+title: Setup HTTPS on Kubernetes with Let's Encrypt
 ---
 
 **This tutorial is obsolete since September 2023**, see [the updated tutorial](./2023-09-26-https-kubernetes-letsencrypt.md).

--- a/posts/2020-04-24-white-noise-angular-power-spectrum.ipynb
+++ b/posts/2020-04-24-white-noise-angular-power-spectrum.ipynb
@@ -15,7 +15,7 @@
     "description: Create a white noise map and compare with power spectrum expected from\n",
     "  the NET\n",
     "output-file: 2020-04-24-white-noise-angular-power-spectrum.html\n",
-    "title: White noise NET in Radio-astronomy and Cosmology\n",
+    "title: White noise NET in radio-astronomy and cosmology\n",
     "\n",
     "---\n",
     "\n"

--- a/posts/2020-09-01-migrate-travisci-readthedocs-github-actions.md
+++ b/posts/2020-09-01-migrate-travisci-readthedocs-github-actions.md
@@ -6,8 +6,7 @@ categories:
 - github
 date: '2020-09-01'
 layout: post
-title: Migrate from Travis-CI and Readthedocs to Github actions
-
+title: Migrate from Travis-CI and ReadTheDocs to GitHub Actions
 ---
 
 For a number of years I have been concerned about the duplication of work having to maintain

--- a/posts/2021-05-20-google-docs-to-overleaf-github.md
+++ b/posts/2021-05-20-google-docs-to-overleaf-github.md
@@ -5,8 +5,7 @@ categories:
 - github
 date: '2021-05-20'
 layout: post
-title: Migrate from Google Docs to Overleaf and Github
-
+title: Migrate from Google Docs to Overleaf and GitHub
 ---
 
 Once a document on Google Docs becomes too big and complicated to make sure it is consistent, it is a good idea to migrate it to Latex.

--- a/posts/2021-08-01-joss-to-arxiv.md
+++ b/posts/2021-08-01-joss-to-arxiv.md
@@ -6,8 +6,7 @@ categories:
 - openscience
 date: '2021-08-01'
 layout: post
-title: Upload a JOSS paper to Arxiv
-
+title: Upload a JOSS paper to arXiv
 ---
 
 If you are in Astrophysics, you probably want to have your [JOSS](https://joss.theoj.org/) paper published to the [Arxiv](https://arxiv.org/).

--- a/posts/2021-11-08-fund-healpy.md
+++ b/posts/2021-11-08-fund-healpy.md
@@ -5,8 +5,7 @@ categories:
 - healpy
 date: '2021-11-08'
 layout: post
-title: Fund healpy via Github Sponsors
-
+title: Fund healpy via GitHub Sponsors
 ---
 
 [**Github Sponsor page**](https://github.com/sponsors/zonca)

--- a/posts/2022-05-02-ssh-github-action.md
+++ b/posts/2022-05-02-ssh-github-action.md
@@ -6,8 +6,7 @@ categories:
 - git
 date: '2022-05-02'
 layout: post
-title: Access running Github action with SSH
-
+title: Access running GitHub Action with SSH
 ---
 
 Sometimes Github actions are failing and it is difficult to reproduce the error locally,

--- a/posts/2022-11-03-singularity-github-actions.md
+++ b/posts/2022-11-03-singularity-github-actions.md
@@ -5,8 +5,7 @@ categories:
 - github
 date: '2022-11-03'
 layout: post
-title: Build and host Singularity containers on Github
-
+title: Build and host Singularity containers on GitHub
 ---
 
 I present a demo repository configured to build Singularity containers using Github actions and then host them using the Github container registry:

--- a/posts/2022-12-01-radio-galaxies-websky-planck.ipynb
+++ b/posts/2022-12-01-radio-galaxies-websky-planck.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "---\n",
-    "title: Compare WebSky Radio Galaxies maps from PySM to Planck\n",
+    "title: Compare WebSky radio galaxies maps from PySM to Planck\n",
     "date: 2022-12-05\n",
     "categories:\n",
     "  - healpy\n",

--- a/posts/2023-02-02-github-overleaf.md
+++ b/posts/2023-02-02-github-overleaf.md
@@ -4,8 +4,7 @@ categories:
 - github
 date: '2023-02-02'
 layout: post
-title: Work on a Latex Document with Github and Overleaf
-
+title: Work on a LaTeX document with GitHub and Overleaf
 ---
 
 In the past I have written about [coordinating a large document using multiple overleaf documents and Github repositories](https://www.zonca.dev/posts/2021-01-28-github-overleaf-large-document).

--- a/posts/2023-03-06-gzip-healpix-healpy.ipynb
+++ b/posts/2023-03-06-gzip-healpix-healpy.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "source": [
     "---\n",
-    "title: Gzipping or not Gzipping HEALPix maps\n",
+    "title: Gzipping or not gzipping HEALPix maps\n",
     "date: 2023-03-06\n",
     "categories:\n",
     "    - healpy\n",

--- a/posts/2023-03-16-latex-github-codespaces.md
+++ b/posts/2023-03-16-latex-github-codespaces.md
@@ -4,8 +4,7 @@ categories:
 - github
 date: '2023-03-16'
 layout: post
-title: Work on a Latex Document in Github Codespaces
-
+title: Work on a LaTeX document in GitHub Codespaces
 ---
 
 I was exploring using Github Codespaces instead of Overleaf to work on a Latex document.

--- a/posts/2023-03-23-update-openstack-credentials-kubernetes.md
+++ b/posts/2023-03-23-update-openstack-credentials-kubernetes.md
@@ -4,8 +4,7 @@ categories:
 - jetstream
 date: '2023-03-23'
 layout: post
-title: Update Openstack credentials in Kubernetes
-
+title: Update OpenStack credentials in Kubernetes
 ---
 
 If you are deploying Kubernetes on top of Openstack, the Openstack External cloud provider stores the ID and Secret necessary to authenticate with the cloud infrastructure in a Secret.

--- a/posts/2023-04-23-hyper-supreme-cam-cosmology.md
+++ b/posts/2023-04-23-hyper-supreme-cam-cosmology.md
@@ -3,8 +3,7 @@ categories:
 - cosmology
 date: '2023-04-23'
 layout: post
-title: Cosmology webinar Hyper Supreme Cam
-
+title: Cosmology webinar Hyper Suprime-Cam
 ---
 
 Webinar about Cosmology results, in particular tension in $S_8$ by the Hyper Supreme Cam collaboration:

--- a/posts/2023-04-24-hiring-computational-scientist-ucsd.md
+++ b/posts/2023-04-24-hiring-computational-scientist-ucsd.md
@@ -4,8 +4,7 @@ categories:
 - sdsc
 date: '2023-04-24'
 layout: post
-title: Hiring a Computational Scientist at the San Diego Supercomputer Center
-
+title: Hiring a computational scientist at the San Diego Supercomputer Center
 ---
 
 * Early Career Scientist? Likes Supercomputers? Likes the Sun?

--- a/posts/2023-10-13-jetstream2-jupyterhub-loadbalancer.md
+++ b/posts/2023-10-13-jetstream2-jupyterhub-loadbalancer.md
@@ -6,8 +6,7 @@ date: '2023-11-06'
 draft: true
 layout: post
 slug: jupyterhub-jetstream2-loadbalancer
-title: Deploy JupyterHub on Jetstream 2 with a Load Balancer
-
+title: Deploy JupyterHub on Jetstream 2 with a load balancer
 ---
 
 **Usage of Load Balancer discouraged**: Deploying load balancers through Kubespray is not reliable, not sure what is the reason for this behaviour. Once created Load Balancers switch between Pending Update and Pending Delete state and cannot be deleted anymore by the user.

--- a/posts/2023-10-27-jupyterhub-github-authentication.md
+++ b/posts/2023-10-27-jupyterhub-github-authentication.md
@@ -7,8 +7,7 @@ categories:
 - github
 date: '2023-09-27'
 layout: post
-title: Deploy Github Authenticator in JupyterHub
-
+title: Deploy GitHub Authenticator in JupyterHub
 ---
 
 **Updated June 2024**: added more options to config file

--- a/posts/2024-02-02-soft-scaling-kubernetes-jetstream.md
+++ b/posts/2024-02-02-soft-scaling-kubernetes-jetstream.md
@@ -6,8 +6,7 @@ categories:
 date: '2024-02-02'
 layout: post
 slug: soft-scaling-kubernetes-jetstream
-title: Soft Scaling Kubernetes on Jetstream
-
+title: Soft scaling Kubernetes on Jetstream
 ---
 
 Work and post contributed by [Ana Espinoza](https://github.com/ana-v-espinoza), only tested and benchmarked by [Andrea Zonca](https://github.com/zonca).

--- a/posts/2024-04-17-overleaf-github-action.md
+++ b/posts/2024-04-17-overleaf-github-action.md
@@ -4,8 +4,7 @@ categories:
 - github
 date: '2024-04-17'
 layout: post
-title: 2-way Synchronization of Overleaf and Github via a Github Action
-
+title: 2-way synchronization of Overleaf and GitHub via a GitHub Action
 ---
 
 **Updated: 2025-02-20**

--- a/posts/2024-05-07-ubuntu22-minimal-image-jetstream.md
+++ b/posts/2024-05-07-ubuntu22-minimal-image-jetstream.md
@@ -7,8 +7,7 @@ aliases:
 - 2024-05-07-ubuntu22-minimal-image-jetstream
 layout: post
 slug: ubuntu22-minimal-image-jetstream
-title: Ubuntu 22.04 Minimal on Jetstream
-
+title: Ubuntu 22.04 minimal on Jetstream
 ---
 
 **Update July 2024**: Ubuntu 22.04 Minimal image with Generic Kernel

--- a/posts/2024-05-13-ubuntu22-minimal-gpu-image-jetstream.md
+++ b/posts/2024-05-13-ubuntu22-minimal-gpu-image-jetstream.md
@@ -5,8 +5,7 @@ categories:
 date: '2024-05-13'
 layout: post
 slug: ubuntu22-minimal-image-gpu-jetstream
-title: Ubuntu 22.04 Minimal on Jetstream with GPU Support
-
+title: Ubuntu 22.04 minimal on Jetstream with GPU support
 ---
 
 Just notes on how to create a Ubuntu 22.04 image with GPU support

--- a/posts/2024-05-29-fastapi-sso-github-organization.md
+++ b/posts/2024-05-29-fastapi-sso-github-organization.md
@@ -5,7 +5,7 @@ categories:
 - github
 date: '2024-05-29'
 layout: post
-title: Authenticate FastAPI endpoints with a Github organization
+title: Authenticate FastAPI endpoints with a GitHub organization
 ---
 
 [FastAPI](https://fastapi.tiangolo.com/) is a framework that simplifies building APIs in Python.

--- a/posts/2024-07-31-pearc-paper-cheapandfair-data-portal.md
+++ b/posts/2024-07-31-pearc-paper-cheapandfair-data-portal.md
@@ -4,7 +4,7 @@ categories:
 layout: post
 date: 2024-07-31
 slug: pearc-paper-cheapandfair-data-portal
-title: PEARC24 Paper Cheap and FAIR Data Portal
+title: PEARC24 paper Cheap and FAIR Data Portal
 ---
 
 In this blog post, we summarize the key points from our recent paper presented at PEARC 2024, titled "Cheap and FAIR: A Serverless Research Data Repository for the Next Generation Cosmic Microwave Background Experiment."

--- a/posts/2024-10-31-jetstream-llm-chat.md
+++ b/posts/2024-10-31-jetstream-llm-chat.md
@@ -7,8 +7,7 @@ categories:
 layout: post
 date: 2024-10-31
 slug: jetstream-llm-chat
-title: Deploy a LLM Chat-GPT like service on Jetstream
-
+title: Deploy an LLM ChatGPT-like service on Jetstream
 ---
 
 In this tutorial we will deploy a LLM Chat-GPT like service on a GPU node on Jetstream.

--- a/posts/2024-12-06-simons-observatory-doi.md
+++ b/posts/2024-12-06-simons-observatory-doi.md
@@ -4,7 +4,7 @@ categories:
 - doi
 date: '2024-12-05'
 layout: post
-title: Proposal for of Simons Observatory Data Products Attribution
+title: Proposal for Simons Observatory data products attribution
 ---
 
 ## License

--- a/posts/2025-01-22-github-release-artifacts.md
+++ b/posts/2025-01-22-github-release-artifacts.md
@@ -3,7 +3,7 @@ categories:
 - github
 date: '2025-01-22'
 layout: post
-title: Using GitHub Releases to keep track of Large Artifacts
+title: Using GitHub Releases to keep track of large artifacts
 ---
 
 ## Introduction

--- a/posts/2025-01-29-github-auth-browser-device-flow.md
+++ b/posts/2025-01-29-github-auth-browser-device-flow.md
@@ -3,7 +3,7 @@ categories:
 - github
 date: '2025-01-29'
 layout: post
-title: Authenticate to GitHub in the Browser with the Device Flow
+title: Authenticate to GitHub in the browser with the device flow
 ---
 
 ## Introduction

--- a/posts/2025-01-29-jupyterlite-save-github.md
+++ b/posts/2025-01-29-jupyterlite-save-github.md
@@ -3,7 +3,7 @@ categories:
 - github
 date: '2025-01-29'
 layout: post
-title: Save Jupyterlite Notebooks to GitHub
+title: Save Jupyterlite notebooks to GitHub
 ---
 
 ## Introduction

--- a/posts/2025-03-03-paper-pysm-models.md
+++ b/posts/2025-03-03-paper-pysm-models.md
@@ -5,7 +5,7 @@ categories:
 - python
 date: '2025-03-03'
 layout: post
-title: New Paper on Arxiv about Models of Galactic Emission in the Microwaves for CMB Experiments
+title: New paper on arXiv about models of Galactic emission in the microwaves for CMB experiments
 ---
 
 A new paper has been published on Arxiv discussing models of Galactic emission in the microwaves for Cosmic Microwave Background (CMB) experiments:

--- a/posts/2025-03-26-tutorial-globus-serverless-research-data-repository.md
+++ b/posts/2025-03-26-tutorial-globus-serverless-research-data-repository.md
@@ -3,7 +3,7 @@ categories:
 - data
 date: '2025-03-26'
 layout: post
-title: Gateways 2024 - Tutorial on Creating a Serverless Research Data Repository based on Globus
+title: Gateways 2024 - Tutorial on creating a serverless research data repository based on Globus
 slug: tutorial-globus-serverless-research-data-repository
 ---
 

--- a/posts/2025-03-30-panexp-model-suite-planck-wmap.md
+++ b/posts/2025-03-30-panexp-model-suite-planck-wmap.md
@@ -4,7 +4,7 @@ categories:
 - cmb
 date: '2025-03-30'
 layout: post
-title: New Simulations of the Panexp Model Suite for Planck and WMAP
+title: New simulations of the Panexp model suite for Planck and WMAP
 ---
 
 Following up on my [recent post about PySM models for Galactic emission](./2025-03-03-paper-pysm-models.md), I have recently executed three new simulations of the Panexp model suite:

--- a/posts/2025-05-01-panexp-model-suite-bk18-websky-catalog.md
+++ b/posts/2025-05-01-panexp-model-suite-bk18-websky-catalog.md
@@ -4,7 +4,7 @@ categories:
 - cmb
 date: '2025-05-01'
 layout: post
-title: BK18 Added to Panexp Model Suite and New Websky Radio Source Models in PySM 3.4.1
+title: BK18 added to Panexp model suite and new WebSky radio source models in PySM 3.4.1
 ---
 
 Following up on my [previous post about Panexp model suite simulations](./2025-03-30-panexp-model-suite-planck-wmap.md), there have been several important updates:

--- a/posts/2025-05-13-vscode-copilot-agent-mode.md
+++ b/posts/2025-05-13-vscode-copilot-agent-mode.md
@@ -1,5 +1,5 @@
 ---
-title: "VS Code Copilot Agent Mode: A Productivity Showcase"
+title: "VS Code Copilot agent mode: A productivity showcase"
 date: 2025-05-13
 categories: [llm, ai]
 ---

--- a/posts/2025-05-23-github-copilot-scientific-computing.md
+++ b/posts/2025-05-23-github-copilot-scientific-computing.md
@@ -5,7 +5,7 @@ categories:
 - python
 date: '2025-05-23'
 layout: post
-title: How to use GitHub Copilot for Scientific Computing
+title: How to use GitHub Copilot for scientific computing
 ---
 
 GitHub Copilot is rapidly transforming the landscape of scientific computing by streamlining code development and accelerating research workflows. This guide outlines how computational scientists can leverage Copilot, with a focus on professional and research-oriented use cases.

--- a/posts/2025-06-04-voyager-access-allocations.md
+++ b/posts/2025-06-04-voyager-access-allocations.md
@@ -4,7 +4,7 @@ categories:
 - sdsc
 date: '2025-06-04'
 layout: post
-title: Voyager enters ACCESS allocations Phase
+title: Voyager enters ACCESS allocations phase
 ---
 
 # Voyager Supercomputer Enters ACCESS Allocations Phase

--- a/posts/2025-06-17-ai-chat-assistant-travel.md
+++ b/posts/2025-06-17-ai-chat-assistant-travel.md
@@ -1,5 +1,5 @@
 ---
-title: "How to Use AI Chat Assistants While Traveling"
+title: "How to use AI chat assistants while traveling"
 date: 2025-06-17
 categories:
   - ai

--- a/posts/2025-09-09-execute-pegasus-jobs-on-expanse.md
+++ b/posts/2025-09-09-execute-pegasus-jobs-on-expanse.md
@@ -1,5 +1,5 @@
 ---
-title: "Execute Pegasus Jobs on Expanse"
+title: "Execute Pegasus jobs on Expanse"
 date: 2025-09-09
 categories:
   - sdsc

--- a/posts/2025-09-18-llm-unshelve.md
+++ b/posts/2025-09-18-llm-unshelve.md
@@ -5,8 +5,7 @@ categories:
 layout: post
 date: 2025-09-18
 slug: llm-unshelve
-title: Timing the Unshelving of a Jetstream 70B LLM Instance
-
+title: Timing the unshelving of a Jetstream 70B LLM instance
 ---
 
 Following the work documented in [Deploy a 70B LLM to Jetstream](2025-09-18-deploy-70b-llm-jetstream.md), the `Meta-Llama-3.1-70B-Instruct-GGUF` deployment is now running on a `g3.xl` instance. The goal of this follow-up is to measure how long it takes to unshelve that virtual machine and bring the chat interface back online.

--- a/posts/2025-09-24-pysm-methods-apj-publication.md
+++ b/posts/2025-09-24-pysm-methods-apj-publication.md
@@ -6,7 +6,7 @@ categories:
 layout: post
 date: 2025-09-24
 slug: pysm-methods-apj-publication
-title: PySM Methods Paper Published in ApJ
+title: PySM methods paper published in ApJ
 image: img/pysm-methods-figure.jpg
 ---
 

--- a/posts/2025-10-07-ezid-doi-management-with-python.md
+++ b/posts/2025-10-07-ezid-doi-management-with-python.md
@@ -1,5 +1,5 @@
 ---
-title: EZID DOI Management with Python
+title: EZID DOI management with Python
 date: '2025-10-07'
 categories:
   - python

--- a/posts/2025-10-07-singularity-github-actions.md
+++ b/posts/2025-10-07-singularity-github-actions.md
@@ -6,8 +6,7 @@ categories:
 - python
 date: '2025-10-07'
 layout: post
-title: Building Singularity Containers with Conda Environments from requirements.txt
-
+title: Building Singularity containers with Conda environments from requirements.txt
 ---
 
 This post introduces a method for building Singularity containers that include a Conda environment based on a `requirements.txt` file. This approach provides a reproducible and portable environment for any Python project.

--- a/posts/2025-10-20-github-actions-auto-merge.md
+++ b/posts/2025-10-20-github-actions-auto-merge.md
@@ -3,7 +3,7 @@ categories:
 - github
 date: '2025-10-20'
 layout: post
-title: Auto-merge GitHub Pull Requests After GitHub Actions Pass
+title: Auto-merge GitHub pull requests after GitHub Actions pass
 ---
 
 Pull request auto-merge is a small feature that keeps teams from babysitting green builds. Once every required check is green, GitHub merges the PR for you—no extra clicks, no late-night merges. Here is how to get it running safely with GitHub Actions.

--- a/posts/2025-11-01-tampermonkey-audible-filter.md
+++ b/posts/2025-11-01-tampermonkey-audible-filter.md
@@ -1,5 +1,5 @@
 ---
-title: "Tampermonkey Script for Audible Filtering"
+title: "Tampermonkey script for Audible filtering"
 author: "Zonca"
 date: "2025-11-01"
 ---

--- a/posts/2025-11-04-updated-tljh-jetstream-tutorial.md
+++ b/posts/2025-11-04-updated-tljh-jetstream-tutorial.md
@@ -2,7 +2,7 @@
 categories: [jupyterhub, jetstream2]
 date: '2025-11-04'
 layout: post
-title: Updated Tutorial on The Littlest JupyterHub on Jetstream
+title: Updated tutorial on The Littlest JupyterHub on Jetstream
 ---
 
 I'm excited to share that I've contributed an updated tutorial on how to deploy "The Littlest JupyterHub" (TLJH) on a Jetstream instance!

--- a/posts/2025-11-10-agentic-scientific-software-development.md
+++ b/posts/2025-11-10-agentic-scientific-software-development.md
@@ -5,7 +5,7 @@ categories:
 - python
 date: '2025-11-10'
 layout: post
-title: Going Full Agentic for Scientific Software Development
+title: Going full agentic for scientific software development
 ---
 
 The landscape of scientific software development is being transformed by AI coding agents. Over the past few weeks, I've been exploring GitHub Copilot's AI coding agent capabilities for maintaining [healpy](https://github.com/healpy/healpy), and the experience has been remarkable. What started as an experiment has evolved into a workflow that feels like managing a team of experienced developers rather than coding alone.

--- a/posts/2025-11-15-nextflow-conditional-branching.md
+++ b/posts/2025-11-15-nextflow-conditional-branching.md
@@ -2,7 +2,7 @@
 categories: [hpc, sdsc, nextflow]
 date: '2025-11-15'
 layout: post
-title: Implementing Conditional Logic in Nextflow Workflows
+title: Implementing conditional logic in Nextflow workflows
 ---
 
 This post serves as a follow-up to my previous tutorial, "[Running Nextflow on Expanse](2025-10-07-running-nextflow-on-expanse.html)", where I covered the foundational aspects of deploying Nextflow workflows on an HPC environment. While the previous discussion focused on execution environments, this tutorial delves into a crucial aspect of building sophisticated and adaptive computational workflows: conditional logic.

--- a/posts/2025-11-15-nextflow-multiple-executors.md
+++ b/posts/2025-11-15-nextflow-multiple-executors.md
@@ -2,7 +2,7 @@
 categories: [hpc, sdsc, nextflow]
 date: '2025-11-15'
 layout: post
-title: Mixing Nextflow Executors for Hybrid Workflows
+title: Mixing Nextflow executors for hybrid workflows
 ---
 
 This post demonstrates how to combine different Nextflow executors within a single workflow, a powerful pattern for optimizing resource usage in scientific computing. By running lightweight tasks locally and offloading computationally intensive processes to HPC clusters like Expanse (as discussed in my [previous tutorial on Nextflow on Expanse](2025-10-07-running-nextflow-on-expanse.html)), users can accelerate development and ensure scalability. This tutorial provides a minimal example of a Nextflow pipeline leveraging both local and Slurm executors.

--- a/posts/2025-12-02-disable-gemini-cli-loading-phrases.md
+++ b/posts/2025-12-02-disable-gemini-cli-loading-phrases.md
@@ -1,5 +1,5 @@
 ---
-title: "Disable Gemini CLI Loading Phrases"
+title: "Disable Gemini CLI loading phrases"
 description: "How to disable the annoying loading phrases in Gemini CLI for a smoother experience."
 author: "Andrea Zonca"
 date: "2025-12-02"

--- a/posts/2025-12-02-ezid-container-product-dois.md
+++ b/posts/2025-12-02-ezid-container-product-dois.md
@@ -1,5 +1,5 @@
 ---
-title: Container and Product EZID DOIs with Python
+title: Container and product EZID DOIs with Python
 date: '2025-12-02'
 categories:
   - python

--- a/posts/2025-12-09-aaron-price-program.md
+++ b/posts/2025-12-09-aaron-price-program.md
@@ -1,5 +1,5 @@
 ---
-title: "The Aaron Price Fellows Program: Fostering Community Leaders"
+title: "The Aaron Price Fellows Program: Fostering community leaders"
 date: "2025-12-09"
 ---
 

--- a/posts/2025-12-11-blm-gaussian-change.ipynb
+++ b/posts/2025-12-11-blm-gaussian-change.ipynb
@@ -14,7 +14,7 @@
     "date: '2025-12-11'\n",
     "description: Analyzing the breaking change in healpy's blm_gauss function (1.18.1 to 1.19.0) and its impact on Gaussian beam coefficients.\n",
     "output-file: 2025-12-11-blm-gaussian-change.html\n",
-    "title: \"Healpy blm_gauss Breaking Change Analysis\"\n",
+    "title: \"Healpy blm_gauss breaking change analysis\"\n",
     "\n",
     "---\n"
    ]

--- a/posts/2025-12-11-jupytext-ai-agents.qmd
+++ b/posts/2025-12-11-jupytext-ai-agents.qmd
@@ -1,5 +1,5 @@
 ---
-title: "Jupytext for AI Agent Jupyter Workflows"
+title: "Jupytext for AI agent Jupyter workflows"
 description: "How using Jupytext with AI coding agents can simplify Jupyter Notebook development by avoiding JSON formatting issues."
 author: "Andrea Zonca"
 date: "2025-12-11"

--- a/posts/2025-12-15-request-access-aws-google-cloud-cloudbank.md
+++ b/posts/2025-12-15-request-access-aws-google-cloud-cloudbank.md
@@ -6,7 +6,7 @@ categories:
 date: 2025-12-15
 layout: post
 slug: request-access-aws-google-cloud-cloudbank
-title: Request Access to AWS and Google Cloud Resources via CloudBank for Scientists
+title: Request access to AWS and Google Cloud resources via CloudBank for scientists
 ---
 
 CloudBank provides a simplified way for scientists and educators to access commercial cloud resources, including Amazon Web Services (AWS) and Google Cloud. Access is free, but requires writing a proposal to justify the requested resources.

--- a/posts/2025-12-16-copy-codex-session.md
+++ b/posts/2025-12-16-copy-codex-session.md
@@ -1,5 +1,5 @@
 ---
-title: "Copy a Single Codex Session to Another Machine"
+title: "Copy a single Codex session to another machine"
 date: "2025-12-16"
 categories: [ai]
 ---

--- a/posts/2025-12-17-cosmosage-launch.md
+++ b/posts/2025-12-17-cosmosage-launch.md
@@ -1,5 +1,5 @@
 ---
-title: "Cosmosage: A Specialized AI Assistant for Cosmology"
+title: "Cosmosage: A specialized AI assistant for cosmology"
 date: 2025-12-17 10:00:00
 categories: [jetstream, llm, cosmology]
 layout: post

--- a/posts/2026-01-01-ai-chatbot-google-form-frontend.md
+++ b/posts/2026-01-01-ai-chatbot-google-form-frontend.md
@@ -1,5 +1,5 @@
 ---
-title: "AI Chatbot as a frontend for a Google Form"
+title: "AI chatbot as a frontend for a Google Form"
 author: "Andrea Zonca"
 date: "2026-01-01"
 categories: [ai]

--- a/posts/2026-01-10-convenience-script-system-cli-updates.md
+++ b/posts/2026-01-10-convenience-script-system-cli-updates.md
@@ -1,5 +1,5 @@
 ---
-title: "Convenience Script for System & CLI Updates"
+title: "Convenience script for system & CLI updates"
 date: "2026-01-10"
 categories: [linux, ai]
 ---

--- a/posts/2026-01-20-kubernetes-jupyterhub-shared-nfs.md
+++ b/posts/2026-01-20-kubernetes-jupyterhub-shared-nfs.md
@@ -5,7 +5,7 @@ categories:
 - jupyterhub
 date: '2026-01-20'
 layout: post
-title: Setting Up Shared NFS Home Directories & Shared Data for JupyterHub on Kubernetes
+title: Setting up shared NFS home directories & shared data for JupyterHub on Kubernetes
 ---
 
 This tutorial provides a walkthrough on how to set up a shared NFS server for JupyterHub users' home directories and shared data.

--- a/posts/2026-01-20-terminal-ai-assistant-github-education.md
+++ b/posts/2026-01-20-terminal-ai-assistant-github-education.md
@@ -1,5 +1,5 @@
 ---
-title: "Terminal-based AI Assistant with GitHub for Education"
+title: "Terminal-based AI assistant with GitHub for Education"
 date: "2026-01-20"
 categories: [ai, github]
 ---

--- a/posts/2026-02-04-jetstream2-manila-jupyterhub-shared-volume.md
+++ b/posts/2026-02-04-jetstream2-manila-jupyterhub-shared-volume.md
@@ -5,7 +5,7 @@ categories:
 - jupyterhub
 date: '2026-02-04'
 layout: post
-title: Create a Manila Share in Exosphere and Mount It for All JupyterHub Users
+title: Create a Manila share in Exosphere and mount it for all JupyterHub users
 ---
 
 This tutorial shows how to create a Manila share in Exosphere and mount it into all JupyterHub single-user pods on Jetstream 2. This provides a ReadWriteMany (RWX) shared filesystem suitable for shared datasets and tools.

--- a/posts/2026-02-06-smithery-gmail-mcp-terminal-ai.md
+++ b/posts/2026-02-06-smithery-gmail-mcp-terminal-ai.md
@@ -1,5 +1,5 @@
 ---
-title: "Connect Gmail (and More) to Codex CLI and Gemini CLI with Smithery (MCP)"
+title: "Connect Gmail (and more) to Codex CLI and Gemini CLI with Smithery (MCP)"
 description: "Use Smithery to connect Gmail, Google Sheets, and Calendar to terminal AI assistants via MCP, with OAuth handled in the browser."
 date: "2026-02-06"
 categories: [ai]

--- a/posts/2026-04-02-release-of-pysm-3.4.4.md
+++ b/posts/2026-04-02-release-of-pysm-3.4.4.md
@@ -5,7 +5,7 @@ categories:
 - python
 date: '2026-04-02'
 layout: post
-title: PySM 3.4.4 Released with New SZ Models and NumPy 2 Support
+title: PySM 3.4.4 released with new SZ models and NumPy 2 support
 ---
 
 PySM 3.4.4 is now available both on [PyPI](https://pypi.org/project/pysm3/3.4.4/) and on [conda-forge](https://anaconda.org/conda-forge/pysm3). This release is mostly about extending the Sunyaev-Zeldovich model suite and making sure PySM works cleanly with NumPy 2.

--- a/posts/2026-04-06-why-3-pixels-per-beam.ipynb
+++ b/posts/2026-04-06-why-3-pixels-per-beam.ipynb
@@ -15,7 +15,7 @@
     "date: '2026-04-06'\n",
     "description: Exploring why the Planck convention uses FWHM = 3 x pixel size for harmonic-space map downgrading, with equations from the literature and simulated demonstrations.\n",
     "output-file: 2026-04-06-why-3-pixels-per-beam.html\n",
-    "title: \"Why 3 Pixels Per Beam? The Mathematics of HEALPix Resolution Matching\"\n",
+    "title: \"Why 3 pixels per beam? The mathematics of HEALPix resolution matching\"\n",
     "\n",
     "---\n"
    ]

--- a/posts/2026-04-13-opencode-byobu-clipboard.md
+++ b/posts/2026-04-13-opencode-byobu-clipboard.md
@@ -1,5 +1,5 @@
 ---
-title: "Fixing Clipboard Issues with Opencode in Byobu/Tmux over SSH on Chromebook"
+title: "Fixing clipboard issues with Opencode in Byobu/Tmux over SSH on Chromebook"
 date: "2026-04-13"
 categories:
   - linux

--- a/posts/2026-04-13-send-email-ucsd-gmail.md
+++ b/posts/2026-04-13-send-email-ucsd-gmail.md
@@ -1,5 +1,5 @@
 ---
-title: "Send email using UCSD SMTP with a GMAIL-based address"
+title: "Send email using UCSD SMTP with a Gmail-based address"
 date: "2026-04-13"
 categories:
 - Python

--- a/posts/2026-05-05-healpy-harmonic-ud-grade.ipynb
+++ b/posts/2026-05-05-healpy-harmonic-ud-grade.ipynb
@@ -14,7 +14,7 @@
     "date: '2026-05-05'\n",
     "description: harmonic_ud_grade vs ud_grade A Focused Comparison.\n",
     "output-file: 2026-05-05-healpy-harmonic-ud-grade.html\n",
-    "title: \"harmonic_ud_grade vs ud_grade: A Focused Comparison\"\n",
+    "title: \"harmonic_ud_grade vs ud_grade: A focused comparison\"\n",
     "\n",
     "---\n"
    ]

--- a/posts/2026-05-17-up-shell-function-update-all-ai-tools.md
+++ b/posts/2026-05-17-up-shell-function-update-all-ai-tools.md
@@ -1,5 +1,5 @@
 ---
-title: "up: One Command to Update All My AI Tools"
+title: "up: One command to update all my AI tools"
 date: "2026-05-17"
 categories: [linux, ai, tools]
 ---

--- a/posts/python-ai-camp-san-diego-2025.md
+++ b/posts/python-ai-camp-san-diego-2025.md
@@ -3,7 +3,7 @@ categories:
 - python
 date: '2025-05-18'
 layout: post
-title: Python and AI Coding Summer Camp in person in San Diego
+title: Python and AI coding summer camp in person in San Diego
 ---
 
 I'm excited to announce that I'll be teaching a brand new **Python and AI Coding Summer Camp** in person in San Diego, hosted at the Italian School of San Diego (Kearny Mesa)!


### PR DESCRIPTION
This PR addresses an issue with strange capitalization in the titles of old blog posts. Titles that were originally in Title Case have been converted to sentence case (only capitalizing the first word and proper nouns). 

A targeted mapping script was used to safely reformat 78 identified titles without inadvertently damaging technical acronyms, program names, human names, or other proper nouns. Formatting across both regular Markdown (`.md` / `.qmd`) and Jupyter Notebook (`.ipynb`) frontmatter has been preserved perfectly.

Verified by successfully building the site using `quarto render`.

---
*PR created automatically by Jules for task [7630574282803891016](https://jules.google.com/task/7630574282803891016) started by @zonca*