### PR TITLE
Update date and metadata for healpy skytools change resolution post

### DIFF
--- a/posts/2026-05-20-healpy-skytools-change-resolution.ipynb
+++ b/posts/2026-05-20-healpy-skytools-change-resolution.ipynb
@@ -1,6 +1,27 @@
 {
  "cells": [
   {
+   "cell_type": "raw",
+   "id": "yaml_frontmatter",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "aliases:\n",
+    "- /posts/2026-05-05-healpy-skytools-change-resolution\n",
+    "- /2026/05/healpy-skytools-change-resolution\n",
+    "categories:\n",
+    "- python\n",
+    "- astrophysics\n",
+    "- healpy\n",
+    "- healpix\n",
+    "- cmb\n",
+    "date: '2026-05-20'\n",
+    "description: 'A comparison of healpy.harmonic_ud_grade and skytools.change_resolution for HEALPix map resolution changes, highlighting API differences, beam/pixel-window support, direct alm input, and agreement levels.'\n",
+    "title: \"healpy harmonic_ud_grade vs skytools change_resolution: A Comparison\"\n",
+    "---\n"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "371bddcf",
    "metadata": {},
@@ -948,15 +969,6 @@
   }
  ],
  "metadata": {
-  "categories": [
-   "python",
-   "astrophysics",
-   "healpy",
-   "healpix",
-   "cmb"
-  ],
-  "date": "2026-05-05",
-  "description": "A comparison of healpy.harmonic_ud_grade and skytools.change_resolution for HEALPix map resolution changes, highlighting API differences, beam/pixel-window support, direct alm input, and agreement levels.",
   "jupytext": {
    "cell_metadata_filter": "-all",
    "main_language": "python",
@@ -977,8 +989,7 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.12.9"
-  },
-  "title": "healpy harmonic_ud_grade vs skytools change_resolution: A Comparison"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 5


### PR DESCRIPTION
Updates the `healpy-skytools-change-resolution.ipynb` post to today's date (2026-05-20), translates its metadata to proper YAML frontmatter inside a raw cell (which fixes metadata formatting issues for Quarto), and ensures the old URL continues to work by adding it as an alias.

---
*PR created automatically by Jules for task [14496395798137445644](https://jules.google.com/task/14496395798137445644) started by @zonca*