### PR TITLE
Fix YAML frontmatter rendering in healpy notebook

### DIFF
--- a/posts/2026-05-29-healpy-1.20.0b1-beta-release.ipynb
+++ b/posts/2026-05-29-healpy-1.20.0b1-beta-release.ipynb
@@ -3,16 +3,7 @@
   {
    "cell_type": "raw",
    "id": "yaml_frontmatter",
-   "metadata": {
-    "papermill": {
-     "duration": 0.004108,
-     "end_time": "2026-05-30T02:01:55.443975+00:00",
-     "exception": false,
-     "start_time": "2026-05-30T02:01:55.439867+00:00",
-     "status": "completed"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "---\n",
     "aliases:\n",
@@ -25,7 +16,7 @@
     "- cmb\n",
     "date: '2026-05-29'\n",
     "description: 'healpy 1.20.0b1 introduces harmonic_ud_grade for artifact-safe HEALPix map downgrading via spherical harmonics, with pixel-window and beam transfer corrections.'\n",
-    "title: healpy 1.20.0b1 beta — harmonic_ud_grade for artifact-safe map downgrading\n",
+    "title: healpy 1.20.0b1 beta \u2014 harmonic_ud_grade for artifact-safe map downgrading\n",
     "---"
    ]
   },
@@ -33,17 +24,10 @@
    "cell_type": "markdown",
    "id": "fd5627aa",
    "metadata": {
-    "papermill": {
-     "duration": 0.003251,
-     "end_time": "2026-05-30T02:01:55.451119+00:00",
-     "exception": false,
-     "start_time": "2026-05-30T02:01:55.447868+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
-    "# healpy 1.20.0b1 beta — `harmonic_ud_grade` for artifact-safe map downgrading\n",
+    "# healpy 1.20.0b1 beta \u2014 `harmonic_ud_grade` for artifact-safe map downgrading\n",
     "\n",
     "    pip install --pre healpy==1.20.0b1\n",
     "\n",
@@ -67,13 +51,6 @@
      "iopub.status.busy": "2026-05-30T02:01:55.459315Z",
      "iopub.status.idle": "2026-05-30T02:01:56.638413Z",
      "shell.execute_reply": "2026-05-30T02:01:56.637039Z"
-    },
-    "papermill": {
-     "duration": 1.185139,
-     "end_time": "2026-05-30T02:01:56.639577+00:00",
-     "exception": false,
-     "start_time": "2026-05-30T02:01:55.454438+00:00",
-     "status": "completed"
     },
     "tags": []
    },
@@ -114,13 +91,6 @@
      "iopub.status.idle": "2026-05-30T02:01:57.191373Z",
      "shell.execute_reply": "2026-05-30T02:01:57.190223Z"
     },
-    "papermill": {
-     "duration": 0.549322,
-     "end_time": "2026-05-30T02:01:57.192915+00:00",
-     "exception": false,
-     "start_time": "2026-05-30T02:01:56.643593+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "outputs": [
@@ -147,17 +117,10 @@
    "cell_type": "markdown",
    "id": "96433b41",
    "metadata": {
-    "papermill": {
-     "duration": 0.002953,
-     "end_time": "2026-05-30T02:01:57.198600+00:00",
-     "exception": false,
-     "start_time": "2026-05-30T02:01:57.195647+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
-    "## `fwhm_out=0` — bandlimit truncation only"
+    "## `fwhm_out=0` \u2014 bandlimit truncation only"
    ]
   },
   {
@@ -170,13 +133,6 @@
      "iopub.status.busy": "2026-05-30T02:01:57.205160Z",
      "iopub.status.idle": "2026-05-30T02:01:58.004777Z",
      "shell.execute_reply": "2026-05-30T02:01:58.003233Z"
-    },
-    "papermill": {
-     "duration": 0.80471,
-     "end_time": "2026-05-30T02:01:58.005783+00:00",
-     "exception": false,
-     "start_time": "2026-05-30T02:01:57.201073+00:00",
-     "status": "completed"
     },
     "tags": []
    },
@@ -201,17 +157,10 @@
    "cell_type": "markdown",
    "id": "0aa62e97",
    "metadata": {
-    "papermill": {
-     "duration": 0.003405,
-     "end_time": "2026-05-30T02:01:58.013424+00:00",
-     "exception": false,
-     "start_time": "2026-05-30T02:01:58.010019+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
-    "## `fwhm_out=None` — effective resolution beam\n",
+    "## `fwhm_out=None` \u2014 effective resolution beam\n",
     "\n",
     "Applies a Gaussian beam with FWHM = $3 \\times \\theta_{\\rm pix}$ at the output NSIDE, following the Planck convention."
    ]
@@ -226,13 +175,6 @@
      "iopub.status.busy": "2026-05-30T02:01:58.020531Z",
      "iopub.status.idle": "2026-05-30T02:01:58.468996Z",
      "shell.execute_reply": "2026-05-30T02:01:58.467887Z"
-    },
-    "papermill": {
-     "duration": 0.453675,
-     "end_time": "2026-05-30T02:01:58.469886+00:00",
-     "exception": false,
-     "start_time": "2026-05-30T02:01:58.016211+00:00",
-     "status": "completed"
     },
     "tags": []
    },
@@ -257,13 +199,6 @@
    "cell_type": "markdown",
    "id": "5ae22ed8",
    "metadata": {
-    "papermill": {
-     "duration": 0.004568,
-     "end_time": "2026-05-30T02:01:58.478391+00:00",
-     "exception": false,
-     "start_time": "2026-05-30T02:01:58.473823+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [
@@ -280,13 +215,6 @@
      "iopub.status.busy": "2026-05-30T02:01:58.485940Z",
      "iopub.status.idle": "2026-05-30T02:01:59.317073Z",
      "shell.execute_reply": "2026-05-30T02:01:59.315351Z"
-    },
-    "papermill": {
-     "duration": 0.836876,
-     "end_time": "2026-05-30T02:01:59.318541+00:00",
-     "exception": false,
-     "start_time": "2026-05-30T02:01:58.481665+00:00",
-     "status": "completed"
     },
     "tags": []
    },
@@ -324,13 +252,6 @@
    "cell_type": "markdown",
    "id": "1e13a0a2",
    "metadata": {
-    "papermill": {
-     "duration": 0.003654,
-     "end_time": "2026-05-30T02:01:59.327990+00:00",
-     "exception": false,
-     "start_time": "2026-05-30T02:01:59.324336+00:00",
-     "status": "completed"
-    },
     "tags": []
    },
    "source": [


### PR DESCRIPTION
Strip papermill metadata from raw cell so Quarto parses the YAML frontmatter correctly.