### PR TITLE
Remove duplicate title and description from blog header

### DIFF
--- a/posts/2026-05-29-healpy-1.20.0b1-beta-release.ipynb
+++ b/posts/2026-05-29-healpy-1.20.0b1-beta-release.ipynb
@@ -5,10 +5,10 @@
    "id": "yaml_frontmatter",
    "metadata": {
     "papermill": {
-     "duration": 0.003675,
-     "end_time": "2026-05-30T05:49:36.004622+00:00",
+     "duration": 0.004469,
+     "end_time": "2026-05-30T05:55:17.459648+00:00",
      "exception": false,
-     "start_time": "2026-05-30T05:49:36.000947+00:00",
+     "start_time": "2026-05-30T05:55:17.455179+00:00",
      "status": "completed"
     },
     "tags": []
@@ -24,7 +24,6 @@
     "- healpix\n",
     "- cmb\n",
     "date: '2026-05-29'\n",
-    "description: 'healpy 1.20.0b1 introduces harmonic_ud_grade for artifact-safe HEALPix map downgrading via spherical harmonics, with pixel-window and beam transfer corrections.'\n",
     "title: healpy 1.20.0b1 beta — harmonic_ud_grade for artifact-safe map downgrading\n",
     "---"
    ]
@@ -34,17 +33,15 @@
    "id": "fd5627aa",
    "metadata": {
     "papermill": {
-     "duration": 0.003358,
-     "end_time": "2026-05-30T05:49:36.012186+00:00",
+     "duration": 0.004066,
+     "end_time": "2026-05-30T05:55:17.467788+00:00",
      "exception": false,
-     "start_time": "2026-05-30T05:49:36.008828+00:00",
+     "start_time": "2026-05-30T05:55:17.463722+00:00",
      "status": "completed"
     },
     "tags": []
    },
    "source": [
-    "# healpy 1.20.0b1 beta — `harmonic_ud_grade` for artifact-safe map downgrading\n",
-    "\n",
     "    pip install --pre healpy==1.20.0b1\n",
     "\n",
     "`harmonic_ud_grade` changes map NSIDE through spherical-harmonic transforms\n",
@@ -63,16 +60,16 @@
    "id": "0bd51f24",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-30T05:49:36.019213Z",
-     "iopub.status.busy": "2026-05-30T05:49:36.018909Z",
-     "iopub.status.idle": "2026-05-30T05:49:37.248673Z",
-     "shell.execute_reply": "2026-05-30T05:49:37.247141Z"
+     "iopub.execute_input": "2026-05-30T05:55:17.477418Z",
+     "iopub.status.busy": "2026-05-30T05:55:17.477117Z",
+     "iopub.status.idle": "2026-05-30T05:55:18.746023Z",
+     "shell.execute_reply": "2026-05-30T05:55:18.744597Z"
     },
     "papermill": {
-     "duration": 1.234496,
-     "end_time": "2026-05-30T05:49:37.249734+00:00",
+     "duration": 1.27571,
+     "end_time": "2026-05-30T05:55:18.747364+00:00",
      "exception": false,
-     "start_time": "2026-05-30T05:49:36.015238+00:00",
+     "start_time": "2026-05-30T05:55:17.471654+00:00",
      "status": "completed"
     },
     "tags": []
@@ -89,7 +86,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/tmp/ipykernel_2269582/3900260292.py:5: HealpyDeprecationWarning: The disable_warnings function is deprecated and may be removed in a future version.\n",
+      "/tmp/ipykernel_2454585/3900260292.py:5: HealpyDeprecationWarning: The disable_warnings function is deprecated and may be removed in a future version.\n",
       "  hp.disable_warnings()\n"
      ]
     }
@@ -109,16 +106,16 @@
    "id": "7e1eaea2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-30T05:49:37.257546Z",
-     "iopub.status.busy": "2026-05-30T05:49:37.257052Z",
-     "iopub.status.idle": "2026-05-30T05:49:37.781347Z",
-     "shell.execute_reply": "2026-05-30T05:49:37.780008Z"
+     "iopub.execute_input": "2026-05-30T05:55:18.756756Z",
+     "iopub.status.busy": "2026-05-30T05:55:18.756262Z",
+     "iopub.status.idle": "2026-05-30T05:55:19.381625Z",
+     "shell.execute_reply": "2026-05-30T05:55:19.380426Z"
     },
     "papermill": {
-     "duration": 0.530172,
-     "end_time": "2026-05-30T05:49:37.783204+00:00",
+     "duration": 0.630984,
+     "end_time": "2026-05-30T05:55:19.382636+00:00",
      "exception": false,
-     "start_time": "2026-05-30T05:49:37.253032+00:00",
+     "start_time": "2026-05-30T05:55:18.751652+00:00",
      "status": "completed"
     },
     "tags": []
@@ -128,7 +125,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/tmp/ipykernel_2269582/2046387934.py:5: HealpyDeprecationWarning: \"verbose\" was deprecated in version 1.15.0 and will be removed in a future version. \n",
+      "/tmp/ipykernel_2454585/2046387934.py:5: HealpyDeprecationWarning: \"verbose\" was deprecated in version 1.15.0 and will be removed in a future version. \n",
       "  m = hp.synfast(cls=np.arange(1, 1001)**(-2.5), nside=nside_in, lmax=3*nside_in-1, verbose=False)\n"
      ]
     }
@@ -146,10 +143,10 @@
    "id": "96433b41",
    "metadata": {
     "papermill": {
-     "duration": 0.003117,
-     "end_time": "2026-05-30T05:49:37.789971+00:00",
+     "duration": 0.002519,
+     "end_time": "2026-05-30T05:55:19.388496+00:00",
      "exception": false,
-     "start_time": "2026-05-30T05:49:37.786854+00:00",
+     "start_time": "2026-05-30T05:55:19.385977+00:00",
      "status": "completed"
     },
     "tags": []
@@ -164,16 +161,16 @@
    "id": "1892ff50",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-30T05:49:37.797838Z",
-     "iopub.status.busy": "2026-05-30T05:49:37.797332Z",
-     "iopub.status.idle": "2026-05-30T05:49:38.672651Z",
-     "shell.execute_reply": "2026-05-30T05:49:38.671266Z"
+     "iopub.execute_input": "2026-05-30T05:55:19.395948Z",
+     "iopub.status.busy": "2026-05-30T05:55:19.395557Z",
+     "iopub.status.idle": "2026-05-30T05:55:20.208274Z",
+     "shell.execute_reply": "2026-05-30T05:55:20.206879Z"
     },
     "papermill": {
-     "duration": 0.889859,
-     "end_time": "2026-05-30T05:49:38.682835+00:00",
+     "duration": 0.82542,
+     "end_time": "2026-05-30T05:55:20.216705+00:00",
      "exception": false,
-     "start_time": "2026-05-30T05:49:37.792976+00:00",
+     "start_time": "2026-05-30T05:55:19.391285+00:00",
      "status": "completed"
     },
     "tags": []
@@ -200,10 +197,10 @@
    "id": "0aa62e97",
    "metadata": {
     "papermill": {
-     "duration": 0.007289,
-     "end_time": "2026-05-30T05:49:38.697996+00:00",
+     "duration": 0.00713,
+     "end_time": "2026-05-30T05:55:20.231937+00:00",
      "exception": false,
-     "start_time": "2026-05-30T05:49:38.690707+00:00",
+     "start_time": "2026-05-30T05:55:20.224807+00:00",
      "status": "completed"
     },
     "tags": []
@@ -220,16 +217,16 @@
    "id": "bcf2f886",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-30T05:49:38.714373Z",
-     "iopub.status.busy": "2026-05-30T05:49:38.714076Z",
-     "iopub.status.idle": "2026-05-30T05:49:39.409915Z",
-     "shell.execute_reply": "2026-05-30T05:49:39.408063Z"
+     "iopub.execute_input": "2026-05-30T05:55:20.248196Z",
+     "iopub.status.busy": "2026-05-30T05:55:20.247840Z",
+     "iopub.status.idle": "2026-05-30T05:55:20.899351Z",
+     "shell.execute_reply": "2026-05-30T05:55:20.897941Z"
     },
     "papermill": {
-     "duration": 0.711963,
-     "end_time": "2026-05-30T05:49:39.417310+00:00",
+     "duration": 0.667024,
+     "end_time": "2026-05-30T05:55:20.906192+00:00",
      "exception": false,
-     "start_time": "2026-05-30T05:49:38.705347+00:00",
+     "start_time": "2026-05-30T05:55:20.239168+00:00",
      "status": "completed"
     },
     "tags": []
@@ -256,10 +253,10 @@
    "id": "5ae22ed8",
    "metadata": {
     "papermill": {
-     "duration": 0.012332,
-     "end_time": "2026-05-30T05:49:39.442624+00:00",
+     "duration": 0.01209,
+     "end_time": "2026-05-30T05:55:20.930814+00:00",
      "exception": false,
-     "start_time": "2026-05-30T05:49:39.430292+00:00",
+     "start_time": "2026-05-30T05:55:20.918724+00:00",
      "status": "completed"
     },
     "tags": []
@@ -274,16 +271,16 @@
    "id": "43d574d4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-30T05:49:39.467733Z",
-     "iopub.status.busy": "2026-05-30T05:49:39.467330Z",
-     "iopub.status.idle": "2026-05-30T05:49:40.171404Z",
-     "shell.execute_reply": "2026-05-30T05:49:40.170301Z"
+     "iopub.execute_input": "2026-05-30T05:55:20.955896Z",
+     "iopub.status.busy": "2026-05-30T05:55:20.955624Z",
+     "iopub.status.idle": "2026-05-30T05:55:21.679834Z",
+     "shell.execute_reply": "2026-05-30T05:55:21.678282Z"
     },
     "papermill": {
-     "duration": 0.718346,
-     "end_time": "2026-05-30T05:49:40.172520+00:00",
+     "duration": 0.738582,
+     "end_time": "2026-05-30T05:55:21.681174+00:00",
      "exception": false,
-     "start_time": "2026-05-30T05:49:39.454174+00:00",
+     "start_time": "2026-05-30T05:55:20.942592+00:00",
      "status": "completed"
     },
     "tags": []
@@ -323,10 +320,10 @@
    "id": "1e13a0a2",
    "metadata": {
     "papermill": {
-     "duration": 0.013219,
-     "end_time": "2026-05-30T05:49:40.199178+00:00",
+     "duration": 0.021145,
+     "end_time": "2026-05-30T05:55:21.723597+00:00",
      "exception": false,
-     "start_time": "2026-05-30T05:49:40.185959+00:00",
+     "start_time": "2026-05-30T05:55:21.702452+00:00",
      "status": "completed"
     },
     "tags": []
@@ -359,14 +356,14 @@
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 6.152365,
-   "end_time": "2026-05-30T05:49:40.732772+00:00",
+   "duration": 6.052977,
+   "end_time": "2026-05-30T05:55:22.259980+00:00",
    "environment_variables": {},
    "exception": null,
    "input_path": "posts/2026-05-29-healpy-1.20.0b1-beta-release.ipynb",
-   "output_path": "/tmp/healpy-beta-fixed.ipynb",
+   "output_path": "/tmp/healpy-beta-noheader.ipynb",
    "parameters": {},
-   "start_time": "2026-05-30T05:49:34.580407+00:00",
+   "start_time": "2026-05-30T05:55:16.207003+00:00",
    "version": "2.7.0"
   }
  },


### PR DESCRIPTION
Remove H1 from markdown cell (YAML title already renders it) and remove description field from frontmatter to avoid rendering it in the page header.