### PR TITLE
Post: Call for Student Volunteers — Summer 2026 HPC & Data Science Institute

### DIFF
--- a/posts/2026-06-03-call-for-student-volunteers-si26.md
+++ b/posts/2026-06-03-call-for-student-volunteers-si26.md
@@ -1,0 +1,59 @@
+---
+title: "Call for Student Volunteers: Summer 2026 HPC & Data Science Institute"
+author: "Andrea Zonca"
+date: "2026-06-03"
+categories: [sdsc, hpc, education]
+description: "We are looking for UC San Diego undergraduates to volunteer as student helpers for the SDSC Summer Institute 2026 — gain hands-on experience in high-performance computing and earn official CCR credit on your transcript."
+---
+
+If you are a UC San Diego undergraduate student with a basic understanding of Linux and Python, and you want practical, resume-worthy experience in high-performance computing, we are looking for you.
+
+The San Diego Supercomputer Center (SDSC) is running two summer training institutes this year, and we need student volunteers to help our instructors during the hands-on sessions. This is a great way to learn about supercomputing while helping others learn too — and you get it on your official transcript.
+
+## What you would do
+
+As a student volunteer, you will:
+
+- Review session materials in advance (about 1-2 hours per session)
+- Be present in the room during hands-on tutorials
+- Walk around and help participants who get stuck on exercises
+
+You do not need to be an expert. Familiarity with the Linux terminal, basic Python, and git is enough. If you have used a cluster or Jupyter notebook before, even better — but it is not required.
+
+## The two institutes
+
+You can volunteer for one or both of these programs:
+
+**CIML Summer Institute** — June 23-25, 2026. Best practices for machine learning on supercomputers.
+
+**HPC & Data Science Summer Institute** — July 23 to August 4, 2026. A week-long introduction to HPC systems, parallel computing, AI/ML workflows, and data science at scale.
+
+## What you get
+
+- **CCR credit on your official UC San Diego transcript.** The Co-Curricular Record is an official university credential that appears alongside your grades. It shows employers and grad schools that you have practical experience beyond coursework.
+- **Hands-on exposure to real supercomputing.** You will see how a professional training program works at one of the world's top HPC centers.
+- **Networking.** Work alongside SDSC staff, researchers, and HPC professionals from across the country.
+- **30+ hours of verified engagement.** Combined across both institutes and preparation time, the total commitment is roughly 30-40 hours.
+
+## Eligibility
+
+- Currently enrolled UC San Diego undergraduate student
+- Basic experience with Linux command line and git
+- Python experience is a plus
+- Available during the institute dates above (plus a few hours of preparation beforehand)
+
+## How to apply
+
+Apply through our Handshake posting: `https://ucsd.joinhandshake.com/public/jobs/11000308`
+
+You need a valid UCSD student account to access Handshake. If you do not have one, you cannot apply through this channel.
+
+Full details about the volunteer role, responsibilities, and CCR credit are on our [Summer Institute internship page](https://github.com/sdsc/sdsc-summer-institute-2026/blob/main/internship.md).
+
+## Questions?
+
+If you have questions about the volunteer program, open an issue in our [Summer Institute 2026 repository](https://github.com/sdsc/sdsc-summer-institute-2026/issues).
+
+---
+
+*This is the first year SDSC is running a dedicated student volunteer program for the Summer Institutes. If you enjoy helping people learn about HPC, this is a great opportunity to get involved.*


### PR DESCRIPTION
Blog post advertising the student volunteer/intern opportunity for the Summer 2026 HPC & Data Science Institute.

Key points:
- Targets UCSD undergraduates
- Links to Handshake posting
- Links to internship.md in sdsc/sdsc-summer-institute-2026 repo
- Questions via GitHub issues (no email published)
- Mentions CCR credit, institute dates, and eligibility