### PR TITLE
Fix lychee timeout and URL exclusions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,8 +49,15 @@ jobs:
           args: >
             --base '${{ github.workspace }}/_site'
             --no-progress
+            --timeout 10
+            --max-concurrency 10
+            --exclude 'https://ucsd\.joinhandshake\.com/**'
+            --exclude 'https://www\.blogger\.com/**'
+            --exclude 'https://twitter\.com/**'
+            --exclude 'https://x\.com/**'
             '_site/**/*.html'
           fail: false
           failIfEmpty: false
           debug: true
+        timeout-minutes: 5
 


### PR DESCRIPTION
Add --timeout 10s, --max-concurrency 10, and exclude joinhandshake.com / twitter.com / x.com URLs from link checking. Also add a 5-minute step timeout to prevent indefinite hangs.